### PR TITLE
Define Sync and Send traits for AudioInfo...

### DIFF
--- a/gstreamer-audio/src/audio_info.rs
+++ b/gstreamer-audio/src/audio_info.rs
@@ -263,6 +263,9 @@ impl PartialEq for AudioInfo {
 
 impl Eq for AudioInfo {}
 
+unsafe impl Sync for AudioInfo {}
+unsafe impl Send for AudioInfo {}
+
 impl glib::types::StaticType for AudioInfo {
     fn static_type() -> glib::types::Type {
         unsafe { glib::translate::from_glib(ffi::gst_audio_info_get_type()) }


### PR DESCRIPTION
... if this is acceptable.

I need this in my `sink_pad.add_probe` closure, because I'd like to avoid reading `AudioInfo` (and `Caps`) on every buffer reception. So I defined a `Mutex<Option<AudioInfo>>` initialized to `None` outside of the closure. When the first buffer arrives, I read the `AudioInfo`, set the `Option` to `Some(audio_info)` and reuse it for subsequent buffers.

Full code is [here](https://github.com/fengalin/media-toc/blob/400649d9a768b7e3138ad4da777cc63dc22e59f7/src/media/context.rs#L172).