### PR TITLE
Bump gtk-rs dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,9 @@ name = "gstreamer-video"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.1.3 (git+https://github.com/gtk-rs/glib)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.1.0",
  "gstreamer-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
  "gstreamer-video-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
@@ -115,7 +115,7 @@ dependencies = [
  "byte-slice-cast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "gio 0.1.3 (git+https://github.com/gtk-rs/gio)",
- "glib 0.1.3 (git+https://github.com/gtk-rs/glib)",
+ "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.1.0",
  "gstreamer-app 0.1.0",
  "gstreamer-audio 0.1.0",
@@ -228,9 +228,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.3.4"
 source = "git+https://github.com/gtk-rs/sys#af83826e0a31f68bcddee17d3791fb01453dc632"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,14 +271,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gstreamer"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.1.3 (git+https://github.com/gtk-rs/glib)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -269,9 +302,9 @@ name = "gstreamer-app"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.1.3 (git+https://github.com/gtk-rs/glib)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.1.0",
  "gstreamer-app-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
  "gstreamer-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
@@ -299,9 +332,9 @@ version = "0.1.0"
 dependencies = [
  "array-init 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.1.3 (git+https://github.com/gtk-rs/glib)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.1.0",
  "gstreamer-audio-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
  "gstreamer-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
@@ -342,9 +375,9 @@ name = "gstreamer-player"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.1.3 (git+https://github.com/gtk-rs/glib)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.1.0",
  "gstreamer-player-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
  "gstreamer-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)",
@@ -693,8 +726,11 @@ dependencies = [
 "checksum gio 0.1.3 (git+https://github.com/gtk-rs/gio)" = "<none>"
 "checksum gio-sys 0.3.4 (git+https://github.com/gtk-rs/sys)" = "<none>"
 "checksum glib 0.1.3 (git+https://github.com/gtk-rs/glib)" = "<none>"
+"checksum glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67eb5b7251562f527d55d0ccf81bc5e6e75045df38b97cfee98ee7b2fc5aa7c0"
 "checksum glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)" = "<none>"
+"checksum glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd7d911c5dc610aabe37caae7d3b9d2cfe6d8f4c85ff4c062f3d6f490e75067"
 "checksum gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)" = "<none>"
+"checksum gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edc95561e538381576425264a4ddd08c65d5da218f10b2a47b4479dd147775da"
 "checksum gstreamer-app-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)" = "<none>"
 "checksum gstreamer-audio-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)" = "<none>"
 "checksum gstreamer-base-sys 0.1.1 (git+https://github.com/sdroege/gstreamer-sys)" = "<none>"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 authors = ["Sebastian Dröge <sebastian@centricular.com>"]
 
 [dependencies]
-glib = { version = "0.1.3", git = "https://github.com/gtk-rs/glib" }
+glib = "0.3.0"
 gstreamer = { path = "../gstreamer" }
 gstreamer-app = { path = "../gstreamer-app" }
 gstreamer-audio = { path = "../gstreamer-audio" }
 gstreamer-video = { path = "../gstreamer-video" }
 gstreamer-player = { path = "../gstreamer-player", optional = true }
-gtk = { version = "0.1.3", git = "https://github.com/gtk-rs/gtk", features = ["v3_6"], optional = true }
-gio = { version = "0.1.3", git = "https://github.com/gtk-rs/gio", optional = true }
+gtk = { version = "0.2.0", features = ["v3_6"], optional = true }
+gio = { version = "0.2.0", optional = true }
 futures = { version = "0.1", optional = true }
 tokio-core = { version = "0.1", optional = true }
 send-cell = "0.1"

--- a/gstreamer-app/Cargo.toml
+++ b/gstreamer-app/Cargo.toml
@@ -13,11 +13,11 @@ build = "build.rs"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 gstreamer-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
 gstreamer-app-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
-glib = { version = "0.1.3", git = "https://github.com/gtk-rs/glib" }
+glib = "0.3.0"
 gstreamer = { version = "0.1.0", path = "../gstreamer" }
 
 [build-dependencies.rustdoc-stripper]

--- a/gstreamer-audio/Cargo.toml
+++ b/gstreamer-audio/Cargo.toml
@@ -13,11 +13,11 @@ build = "build.rs"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 gstreamer-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
 gstreamer-audio-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
-glib = { version = "0.1.3", git = "https://github.com/gtk-rs/glib" }
+glib = "0.3.0"
 gstreamer = { version = "0.1.0", path = "../gstreamer" }
 array-init = "0.0"
 

--- a/gstreamer-player/Cargo.toml
+++ b/gstreamer-player/Cargo.toml
@@ -13,11 +13,11 @@ build = "build.rs"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 gstreamer-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_12"] }
 gstreamer-player-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_12"] }
-glib = { version = "0.1.3", git = "https://github.com/gtk-rs/glib" }
+glib = "0.3.0"
 gstreamer = { version = "0.1.0", path = "../gstreamer", features = ["v1_12"] }
 
 [build-dependencies.rustdoc-stripper]

--- a/gstreamer-video/Cargo.toml
+++ b/gstreamer-video/Cargo.toml
@@ -13,11 +13,11 @@ build = "build.rs"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 gstreamer-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
 gstreamer-video-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
-glib = { version = "0.1.3", git = "https://github.com/gtk-rs/glib" }
+glib = "0.3.0"
 gstreamer = { version = "0.1.0", path = "../gstreamer" }
 
 [build-dependencies.rustdoc-stripper]

--- a/gstreamer/Cargo.toml
+++ b/gstreamer/Cargo.toml
@@ -13,10 +13,10 @@ build = "build.rs"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 gstreamer-sys = { version = "0.1.1", git = "https://github.com/sdroege/gstreamer-sys", features = ["v1_8"] }
-glib = { version = "0.1.3", git = "https://github.com/gtk-rs/glib" }
+glib = "0.3.0"
 num-rational = { version = "0.1.38", default-features = false, features = [] }
 lazy_static = "0.2"
 futures = { version = "0.1", optional = true }


### PR DESCRIPTION
glib 0.1.3 and {gobject,glib}-sys 0.3.4 were not tagged in Github and were
updated to newer versions.

This commit is likely incomplete because it depends on not-yet-merged
https://github.com/sdroege/gstreamer-sys/pull/1