### PR TITLE
Set version (1.12) for StackTraceFlags

### DIFF
--- a/gir-files/Gst-1.0.gir
+++ b/gir-files/Gst-1.0.gir
@@ -35158,7 +35158,8 @@ values of the seek flags.</doc>
     <bitfield name="StackTraceFlags"
               glib:type-name="GstStackTraceFlags"
               glib:get-type="gst_stack_trace_flags_get_type"
-              c:type="GstStackTraceFlags">
+              c:type="GstStackTraceFlags"
+              version="1.12">
       <member name="full"
               value="1"
               c:identifier="GST_STACK_TRACE_SHOW_FULL"

--- a/gstreamer/src/auto/flags.rs
+++ b/gstreamer/src/auto/flags.rs
@@ -567,12 +567,14 @@ impl SetValue for SegmentFlags {
     }
 }
 
+#[cfg(feature = "v1_12")]
 bitflags! {
     pub struct StackTraceFlags: u32 {
         const STACK_TRACE_SHOW_FULL = 1;
     }
 }
 
+#[cfg(feature = "v1_12")]
 #[doc(hidden)]
 impl ToGlib for StackTraceFlags {
     type GlibType = ffi::GstStackTraceFlags;
@@ -582,6 +584,7 @@ impl ToGlib for StackTraceFlags {
     }
 }
 
+#[cfg(feature = "v1_12")]
 #[doc(hidden)]
 impl FromGlib<ffi::GstStackTraceFlags> for StackTraceFlags {
     fn from_glib(value: ffi::GstStackTraceFlags) -> StackTraceFlags {
@@ -590,24 +593,28 @@ impl FromGlib<ffi::GstStackTraceFlags> for StackTraceFlags {
     }
 }
 
+#[cfg(feature = "v1_12")]
 impl StaticType for StackTraceFlags {
     fn static_type() -> Type {
         unsafe { from_glib(ffi::gst_stack_trace_flags_get_type()) }
     }
 }
 
+#[cfg(feature = "v1_12")]
 impl<'a> FromValueOptional<'a> for StackTraceFlags {
     unsafe fn from_value_optional(value: &Value) -> Option<Self> {
         Some(FromValue::from_value(value))
     }
 }
 
+#[cfg(feature = "v1_12")]
 impl<'a> FromValue<'a> for StackTraceFlags {
     unsafe fn from_value(value: &Value) -> Self {
         from_glib(ffi::GstStackTraceFlags::from_bits_truncate(gobject_ffi::g_value_get_flags(value.to_glib_none().0)))
     }
 }
 
+#[cfg(feature = "v1_12")]
 impl SetValue for StackTraceFlags {
     unsafe fn set_value(value: &mut Value, this: &Self) {
         gobject_ffi::g_value_set_flags(value.to_glib_none_mut().0, this.to_glib().bits())

--- a/gstreamer/src/auto/mod.rs
+++ b/gstreamer/src/auto/mod.rs
@@ -244,7 +244,9 @@ pub use self::flags::SEGMENT_FLAG_SKIP;
 pub use self::flags::SEGMENT_FLAG_SEGMENT;
 pub use self::flags::SEGMENT_FLAG_TRICKMODE_KEY_UNITS;
 pub use self::flags::SEGMENT_FLAG_TRICKMODE_NO_AUDIO;
+#[cfg(feature = "v1_12")]
 pub use self::flags::StackTraceFlags;
+#[cfg(feature = "v1_12")]
 pub use self::flags::STACK_TRACE_SHOW_FULL;
 pub use self::flags::StreamFlags;
 pub use self::flags::STREAM_FLAG_NONE;


### PR DESCRIPTION
If understand correctly, `StackTraceFlags` was added to `gstinfo.h` after version 1.10.

See also https://github.com/sdroege/gstreamer-sys/pull/2