### PR TITLE
Unnecessary reference

### DIFF
--- a/examples/src/bin/utils/mod.rs
+++ b/examples/src/bin/utils/mod.rs
@@ -30,7 +30,7 @@ impl fmt::Display for ExampleError {
             ExampleError::ElementError(ref element, ref err, ref debug) => {
                 write!(f, "Error from {}: {} ({:?})", element, err, debug)
             }
-            ExampleError::MissingFeature(ref feature) => write!(
+            ExampleError::MissingFeature(feature) => write!(
                 f,
                 "Feature {} is required. Please rebuild with --features {}",
                 feature,


### PR DESCRIPTION
This creates a reference to a reference, clean it.

Fix for #47 