### PR TITLE
gstreamer-player: regen for overridden signals

### DIFF
--- a/Gir_GstPlayer.toml
+++ b/Gir_GstPlayer.toml
@@ -78,6 +78,8 @@ trait = false
     [[object.signal]]
     name = "duration-changed"
     concurrency = "send"
+    # Pass ClockTime instead of u64
+    ignore = true
 
     [[object.signal]]
     name = "end-of-stream"
@@ -96,12 +98,16 @@ trait = false
     concurrency = "send"
 
     [[object.signal]]
-    name = "position-changed"
+    name = "position-updated"
     concurrency = "send"
+    # Pass ClockTime instead of u64
+    ignore = true
 
     [[object.signal]]
     name = "seek-done"
     concurrency = "send"
+    # Pass ClockTime instead of u64
+    ignore = true
 
     [[object.signal]]
     name = "state-changed"

--- a/gstreamer-player/src/auto/player.rs
+++ b/gstreamer-player/src/auto/player.rs
@@ -396,14 +396,6 @@ impl Player {
         }
     }
 
-    pub fn connect_duration_changed<F: Fn(&Player, u64) + Send + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe {
-            let f: Box_<Box_<Fn(&Player, u64) + Send + 'static>> = Box_::new(Box_::new(f));
-            connect(self.to_glib_none().0, "duration-changed",
-                transmute(duration_changed_trampoline as usize), Box_::into_raw(f) as *mut _)
-        }
-    }
-
     pub fn connect_end_of_stream<F: Fn(&Player) + Send + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe {
             let f: Box_<Box_<Fn(&Player) + Send + 'static>> = Box_::new(Box_::new(f));
@@ -433,22 +425,6 @@ impl Player {
             let f: Box_<Box_<Fn(&Player) + Send + 'static>> = Box_::new(Box_::new(f));
             connect(self.to_glib_none().0, "mute-changed",
                 transmute(mute_changed_trampoline as usize), Box_::into_raw(f) as *mut _)
-        }
-    }
-
-    pub fn connect_position_updated<F: Fn(&Player, u64) + Send + Sync + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe {
-            let f: Box_<Box_<Fn(&Player, u64) + Send + Sync + 'static>> = Box_::new(Box_::new(f));
-            connect(self.to_glib_none().0, "position-updated",
-                transmute(position_updated_trampoline as usize), Box_::into_raw(f) as *mut _)
-        }
-    }
-
-    pub fn connect_seek_done<F: Fn(&Player, u64) + Send + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe {
-            let f: Box_<Box_<Fn(&Player, u64) + Send + 'static>> = Box_::new(Box_::new(f));
-            connect(self.to_glib_none().0, "seek-done",
-                transmute(seek_done_trampoline as usize), Box_::into_raw(f) as *mut _)
         }
     }
 
@@ -638,12 +614,6 @@ unsafe extern "C" fn buffering_trampoline(this: *mut ffi::GstPlayer, object: lib
     f(&from_glib_borrow(this), object)
 }
 
-unsafe extern "C" fn duration_changed_trampoline(this: *mut ffi::GstPlayer, object: u64, f: glib_ffi::gpointer) {
-    callback_guard!();
-    let f: &&(Fn(&Player, u64) + Send + 'static) = transmute(f);
-    f(&from_glib_borrow(this), object)
-}
-
 unsafe extern "C" fn end_of_stream_trampoline(this: *mut ffi::GstPlayer, f: glib_ffi::gpointer) {
     callback_guard!();
     let f: &&(Fn(&Player) + Send + 'static) = transmute(f);
@@ -666,18 +636,6 @@ unsafe extern "C" fn mute_changed_trampoline(this: *mut ffi::GstPlayer, f: glib_
     callback_guard!();
     let f: &&(Fn(&Player) + Send + 'static) = transmute(f);
     f(&from_glib_borrow(this))
-}
-
-unsafe extern "C" fn position_updated_trampoline(this: *mut ffi::GstPlayer, object: u64, f: glib_ffi::gpointer) {
-    callback_guard!();
-    let f: &&(Fn(&Player, u64) + Send + Sync + 'static) = transmute(f);
-    f(&from_glib_borrow(this), object)
-}
-
-unsafe extern "C" fn seek_done_trampoline(this: *mut ffi::GstPlayer, object: u64, f: glib_ffi::gpointer) {
-    callback_guard!();
-    let f: &&(Fn(&Player, u64) + Send + 'static) = transmute(f);
-    f(&from_glib_borrow(this), object)
 }
 
 unsafe extern "C" fn state_changed_trampoline(this: *mut ffi::GstPlayer, object: ffi::GstPlayerState, f: glib_ffi::gpointer) {


### PR DESCRIPTION
In the previous generated player bindings the position-updated was Send+Sync but
only Send is actually needed. In addition to this change the position-updated
and seek-done signals now invoke their handler with a gst::ClockTime value
instead of u64.