### PR TITLE
Pad: allow pad probes to capture their environment as mutable

### DIFF
--- a/gstreamer/src/pad.rs
+++ b/gstreamer/src/pad.rs
@@ -104,7 +104,7 @@ impl Drop for StreamLock {
 pub trait PadExtManual {
     fn add_probe<F>(&self, mask: PadProbeType, func: F) -> PadProbeId
     where
-        F: Fn(&Pad, &mut PadProbeInfo) -> PadProbeReturn + Send + Sync + 'static;
+        F: FnMut(&Pad, &mut PadProbeInfo) -> PadProbeReturn + Send + Sync + 'static;
     fn remove_probe(&self, id: PadProbeId);
 
     fn chain(&self, buffer: Buffer) -> FlowReturn;
@@ -227,11 +227,11 @@ pub trait PadExtManual {
 impl<O: IsA<Pad>> PadExtManual for O {
     fn add_probe<F>(&self, mask: PadProbeType, func: F) -> PadProbeId
     where
-        F: Fn(&Pad, &mut PadProbeInfo) -> PadProbeReturn + Send + Sync + 'static,
+        F: FnMut(&Pad, &mut PadProbeInfo) -> PadProbeReturn + Send + Sync + 'static,
     {
         unsafe {
             let func_box: Box<
-                Fn(&Pad, &mut PadProbeInfo) -> PadProbeReturn + Send + Sync + 'static,
+                FnMut(&Pad, &mut PadProbeInfo) -> PadProbeReturn + Send + Sync + 'static,
             > = Box::new(func);
             let id = ffi::gst_pad_add_probe(
                 self.to_glib_none().0,


### PR DESCRIPTION
Example use case:

``` rust
    let mut is_done = AtomicBool::new(false);
    sink_pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, probe_info| {
         let mut is_cndt_lck = is_cndt.get_mut();
         if !*is_done_lck {
             // Do stuff
             *is_done_lck = true;
         } else {
             // Do other stuff
         }
         ...
    }
```

I think this is valid because the function for `add_probe` is constrained to be `Send + Sync`.
If we only allow for `Fn` functions, the inner condition must be a clone to an `Arc<Mutex<bool>>`.