### PR TITLE
Document dependency for libgstreamer-plugins-bad1.0-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,22 @@ On Debian/Ubuntu they can be installed with
 
 ```
 $ apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-      libgstreamer-plugins-bad1.0-dev \
       gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
       gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       gstreamer1.0-libav
+```
+
+The minimum required version of the above libraries is >= 1.8. If you
+build the gstreamer-player sub-crate, or any of the examples that
+depend on gstreamer-player, you must ensure that in addition to the
+above packages, `libgstreamer-plugins-bad1.0-dev` is installed and
+that the version is >= 1.12. See the `Cargo.toml` files for the full
+details,
+
+```
+# Only if you wish to install gstreamer-player, make sure the version
+# of this package is >= 1.12.
+$ apt-get install libgstreamer-plugins-bad1.0-dev
 ```
 
 Package names on other distributions should be similar.
@@ -69,6 +81,10 @@ provided by the GStreamer project.
 $ brew install gstreamer gst-plugins-base gst-plugins-good \
       gst-plugins-bad gst-plugins-ugly gst-libav
 ```
+
+If you wish to install the gstreamer-player sub-crate, make sure the
+version of these libraries is >= 1.12. Otherwise, a version >= 1.8 is
+sufficient.
 
 #### GStreamer Binaries
 
@@ -99,6 +115,10 @@ $ pacman -S pkg-config mingw-w64-x86_64-gstreamer mingw-w64-x86_64-gst-plugins-b
       mingw-w64-x86_64-gst-plugins-good mingw-w64-x86_64-gst-plugins-bad \
       mingw-w64-x86_64-gst-plugins-ugly mingw-w64-x86_64-gst-libav
 ```
+
+If you wish to install the gstreamer-player sub-crate, make sure the
+version of these libraries is >= 1.12. Otherwise, a version >= 1.8 is
+sufficient.
 
 #### GStreamer Binaries
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ On Debian/Ubuntu they can be installed with
 
 ```
 $ apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+      libgstreamer-plugins-bad1.0-dev \
       gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
       gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
       gstreamer1.0-libav


### PR DESCRIPTION
I saw this after doing a fresh checkout on Ubuntu 17.10,

```
error: failed to run custom build command for `gstreamer-player-sys v0.5.0 (https://github.com/sdroege/gstreamer-sys#d68a12a4)`
process didn't exit successfully: `/home/charlie/git/gstreamer-rs/target/debug/build/gstreamer-player-sys-8838fb523b245540/build-script-build` (exit code: 1)
--- stderr
`"pkg-config" "--libs" "--cflags" "gstreamer-player-1.0 >= 1.12"` did not exit successfully: exit code: 1
--- stderr
Package gstreamer-player-1.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gstreamer-player-1.0.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gstreamer-player-1.0' found


warning: build failed, waiting for other jobs to finish...
error: build failed
```

Add this dependency fixed the issue here. I assume the same will be true on Debian, but I haven't tested.