### PR TITLE
Event, Message & Query: allow dereferencing concrete types to access generic type methods

### DIFF
--- a/examples/src/bin/appsink.rs
+++ b/examples/src/bin/appsink.rs
@@ -137,7 +137,7 @@ fn main_loop(pipeline: gst::Pipeline) -> Result<(), Error> {
             MessageView::Error(err) => {
                 pipeline.set_state(gst::State::Null).into_result()?;
                 Err(ErrorMessage {
-                    src: msg.get_src()
+                    src: err.get_src()
                         .map(|s| s.get_path_string())
                         .unwrap_or_else(|| String::from("None")),
                     error: err.get_error().description().into(),

--- a/examples/src/bin/appsrc.rs
+++ b/examples/src/bin/appsrc.rs
@@ -111,7 +111,7 @@ fn main_loop(pipeline: gst::Pipeline, appsrc: gst_app::AppSrc) -> Result<(), Err
             MessageView::Error(err) => {
                 pipeline.set_state(gst::State::Null).into_result()?;
                 Err(ErrorMessage {
-                    src: msg.get_src()
+                    src: err.get_src()
                         .map(|s| s.get_path_string())
                         .unwrap_or_else(|| String::from("None")),
                     error: err.get_error().description().into(),

--- a/examples/src/bin/decodebin.rs
+++ b/examples/src/bin/decodebin.rs
@@ -174,7 +174,7 @@ fn example_main() -> Result<(), Error> {
                             .map(Result::Err)
                             .expect("error-details message without actual error"),
                         _ => Err(ErrorMessage {
-                            src: msg.get_src()
+                            src: err.get_src()
                                 .map(|s| s.get_path_string())
                                 .unwrap_or_else(|| String::from("None")),
                             error: err.get_error().description().into(),
@@ -186,7 +186,7 @@ fn example_main() -> Result<(), Error> {
                 #[cfg(not(feature = "v1_10"))]
                 {
                     Err(ErrorMessage {
-                        src: msg.get_src()
+                        src: err.get_src()
                             .map(|s| s.get_path_string())
                             .unwrap_or_else(|| String::from("None")),
                         error: err.get_error().description().into(),
@@ -199,7 +199,7 @@ fn example_main() -> Result<(), Error> {
             MessageView::StateChanged(s) => {
                 println!(
                     "State changed from {:?}: {:?} -> {:?} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    s.get_src().map(|s| s.get_path_string()),
                     s.get_old(),
                     s.get_current(),
                     s.get_pending()

--- a/examples/src/bin/events.rs
+++ b/examples/src/bin/events.rs
@@ -45,7 +45,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/gtksink.rs
+++ b/examples/src/bin/gtksink.rs
@@ -89,7 +89,7 @@ fn create_ui(app: &gtk::Application) {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/gtkvideooverlay.rs
+++ b/examples/src/bin/gtkvideooverlay.rs
@@ -159,7 +159,7 @@ fn create_ui(app: &gtk::Application) {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/launch.rs
+++ b/examples/src/bin/launch.rs
@@ -39,7 +39,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/launch_glib_main.rs
+++ b/examples/src/bin/launch_glib_main.rs
@@ -34,7 +34,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/pad_probes.rs
+++ b/examples/src/bin/pad_probes.rs
@@ -61,7 +61,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/playbin.rs
+++ b/examples/src/bin/playbin.rs
@@ -76,7 +76,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/queries.rs
+++ b/examples/src/bin/queries.rs
@@ -73,7 +73,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/tagsetter.rs
+++ b/examples/src/bin/tagsetter.rs
@@ -71,7 +71,7 @@ fn example_main() -> Result<(), Error> {
             MessageView::Eos(..) => break,
             MessageView::Error(err) => {
                 Err(ErrorMessage {
-                    src: msg.get_src()
+                    src: err.get_src()
                         .map(|s| s.get_path_string())
                         .unwrap_or_else(|| String::from("None")),
                     error: err.get_error().description().into(),

--- a/examples/src/bin/toc.rs
+++ b/examples/src/bin/toc.rs
@@ -63,7 +63,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/examples/src/bin/tokio.rs
+++ b/examples/src/bin/tokio.rs
@@ -41,7 +41,7 @@ fn example_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/gstreamer/src/event.rs
+++ b/gstreamer/src/event.rs
@@ -16,6 +16,7 @@ use std::mem;
 use std::cmp;
 use std::fmt;
 use std::ffi::CStr;
+use std::ops::Deref;
 
 use glib;
 use glib::value::ToSendValue;
@@ -494,28 +495,42 @@ pub enum EventView<'a> {
     __NonExhaustive,
 }
 
-pub struct FlushStart<'a>(&'a EventRef);
+macro_rules! declare_concrete_event(
+    ($name:ident) => {
+        pub struct $name<'a>(&'a EventRef);
 
-pub struct FlushStop<'a>(&'a EventRef);
+        impl<'a> Deref for $name<'a> {
+            type Target = EventRef;
+
+            fn deref(&self) -> &Self::Target {
+                self.0
+            }
+        }
+    }
+);
+
+declare_concrete_event!(FlushStart);
+
+declare_concrete_event!(FlushStop);
 impl<'a> FlushStop<'a> {
     pub fn get_reset_time(&self) -> bool {
         unsafe {
             let mut reset_time = mem::uninitialized();
 
-            ffi::gst_event_parse_flush_stop(self.0.as_mut_ptr(), &mut reset_time);
+            ffi::gst_event_parse_flush_stop(self.as_mut_ptr(), &mut reset_time);
 
             from_glib(reset_time)
         }
     }
 }
 
-pub struct StreamStart<'a>(&'a EventRef);
+declare_concrete_event!(StreamStart);
 impl<'a> StreamStart<'a> {
     pub fn get_stream_id(&self) -> &'a str {
         unsafe {
             let mut stream_id = ptr::null();
 
-            ffi::gst_event_parse_stream_start(self.0.as_mut_ptr(), &mut stream_id);
+            ffi::gst_event_parse_stream_start(self.as_mut_ptr(), &mut stream_id);
             CStr::from_ptr(stream_id).to_str().unwrap()
         }
     }
@@ -524,7 +539,7 @@ impl<'a> StreamStart<'a> {
         unsafe {
             let mut stream_flags = mem::uninitialized();
 
-            ffi::gst_event_parse_stream_flags(self.0.as_mut_ptr(), &mut stream_flags);
+            ffi::gst_event_parse_stream_flags(self.as_mut_ptr(), &mut stream_flags);
 
             from_glib(stream_flags)
         }
@@ -534,63 +549,63 @@ impl<'a> StreamStart<'a> {
         unsafe {
             let mut group_id = mem::uninitialized();
 
-            ffi::gst_event_parse_group_id(self.0.as_mut_ptr(), &mut group_id);
+            ffi::gst_event_parse_group_id(self.as_mut_ptr(), &mut group_id);
 
             from_glib(group_id)
         }
     }
 }
 
-pub struct Caps<'a>(&'a EventRef);
+declare_concrete_event!(Caps);
 impl<'a> Caps<'a> {
     pub fn get_caps(&self) -> &'a ::CapsRef {
         unsafe {
             let mut caps = ptr::null_mut();
 
-            ffi::gst_event_parse_caps(self.0.as_mut_ptr(), &mut caps);
+            ffi::gst_event_parse_caps(self.as_mut_ptr(), &mut caps);
             ::CapsRef::from_ptr(caps)
         }
     }
 }
 
-pub struct Segment<'a>(&'a EventRef);
+declare_concrete_event!(Segment);
 impl<'a> Segment<'a> {
     pub fn get_segment(&self) -> &'a ::Segment {
         unsafe {
             let mut segment = ptr::null();
 
-            ffi::gst_event_parse_segment(self.0.as_mut_ptr(), &mut segment);
+            ffi::gst_event_parse_segment(self.as_mut_ptr(), &mut segment);
             &*(segment as *mut ffi::GstSegment as *mut ::Segment)
         }
     }
 }
 
-pub struct StreamCollection<'a>(&'a EventRef);
+declare_concrete_event!(StreamCollection);
 impl<'a> StreamCollection<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_stream_collection(&self) -> ::StreamCollection {
         unsafe {
             let mut stream_collection = ptr::null_mut();
 
-            ffi::gst_event_parse_stream_collection(self.0.as_mut_ptr(), &mut stream_collection);
+            ffi::gst_event_parse_stream_collection(self.as_mut_ptr(), &mut stream_collection);
             from_glib_full(stream_collection)
         }
     }
 }
 
-pub struct Tag<'a>(&'a EventRef);
+declare_concrete_event!(Tag);
 impl<'a> Tag<'a> {
     pub fn get_tag(&self) -> &'a ::TagListRef {
         unsafe {
             let mut tags = ptr::null_mut();
 
-            ffi::gst_event_parse_tag(self.0.as_mut_ptr(), &mut tags);
+            ffi::gst_event_parse_tag(self.as_mut_ptr(), &mut tags);
             ::TagListRef::from_ptr(tags)
         }
     }
 }
 
-pub struct BufferSize<'a>(&'a EventRef);
+declare_concrete_event!(BufferSize);
 impl<'a> BufferSize<'a> {
     pub fn get(&self) -> (GenericFormattedValue, GenericFormattedValue, bool) {
         unsafe {
@@ -600,7 +615,7 @@ impl<'a> BufferSize<'a> {
             let mut async = mem::uninitialized();
 
             ffi::gst_event_parse_buffer_size(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut fmt,
                 &mut minsize,
                 &mut maxsize,
@@ -615,48 +630,48 @@ impl<'a> BufferSize<'a> {
     }
 }
 
-pub struct SinkMessage<'a>(&'a EventRef);
+declare_concrete_event!(SinkMessage);
 impl<'a> SinkMessage<'a> {
     pub fn get_message(&self) -> ::Message {
         unsafe {
             let mut msg = ptr::null_mut();
 
-            ffi::gst_event_parse_sink_message(self.0.as_mut_ptr(), &mut msg);
+            ffi::gst_event_parse_sink_message(self.as_mut_ptr(), &mut msg);
             from_glib_full(msg)
         }
     }
 }
 
-pub struct StreamGroupDone<'a>(&'a EventRef);
+declare_concrete_event!(StreamGroupDone);
 impl<'a> StreamGroupDone<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_group_id(&self) -> GroupId {
         unsafe {
             let mut group_id = mem::uninitialized();
 
-            ffi::gst_event_parse_stream_group_done(self.0.as_mut_ptr(), &mut group_id);
+            ffi::gst_event_parse_stream_group_done(self.as_mut_ptr(), &mut group_id);
 
             from_glib(group_id)
         }
     }
 }
 
-pub struct Eos<'a>(&'a EventRef);
+declare_concrete_event!(Eos);
 
-pub struct Toc<'a>(&'a EventRef);
+declare_concrete_event!(Toc);
 impl<'a> Toc<'a> {
     pub fn get_toc(&self) -> (&'a ::TocRef, bool) {
         unsafe {
             let mut toc = ptr::null_mut();
             let mut updated = mem::uninitialized();
 
-            ffi::gst_event_parse_toc(self.0.as_mut_ptr(), &mut toc, &mut updated);
+            ffi::gst_event_parse_toc(self.as_mut_ptr(), &mut toc, &mut updated);
             (::TocRef::from_ptr(toc), from_glib(updated))
         }
     }
 }
 
-pub struct Protection<'a>(&'a EventRef);
+declare_concrete_event!(Protection);
 impl<'a> Protection<'a> {
     pub fn get(&self) -> (&'a str, &'a ::BufferRef, Option<&'a str>) {
         unsafe {
@@ -665,7 +680,7 @@ impl<'a> Protection<'a> {
             let mut origin = ptr::null();
 
             ffi::gst_event_parse_protection(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut system_id,
                 &mut buffer,
                 &mut origin,
@@ -684,35 +699,35 @@ impl<'a> Protection<'a> {
     }
 }
 
-pub struct SegmentDone<'a>(&'a EventRef);
+declare_concrete_event!(SegmentDone);
 impl<'a> SegmentDone<'a> {
     pub fn get(&self) -> GenericFormattedValue {
         unsafe {
             let mut fmt = mem::uninitialized();
             let mut position = mem::uninitialized();
 
-            ffi::gst_event_parse_segment_done(self.0.as_mut_ptr(), &mut fmt, &mut position);
+            ffi::gst_event_parse_segment_done(self.as_mut_ptr(), &mut fmt, &mut position);
 
             GenericFormattedValue::new(from_glib(fmt), position)
         }
     }
 }
 
-pub struct Gap<'a>(&'a EventRef);
+declare_concrete_event!(Gap);
 impl<'a> Gap<'a> {
     pub fn get(&self) -> (::ClockTime, ::ClockTime) {
         unsafe {
             let mut timestamp = mem::uninitialized();
             let mut duration = mem::uninitialized();
 
-            ffi::gst_event_parse_gap(self.0.as_mut_ptr(), &mut timestamp, &mut duration);
+            ffi::gst_event_parse_gap(self.as_mut_ptr(), &mut timestamp, &mut duration);
 
             (from_glib(timestamp), from_glib(duration))
         }
     }
 }
 
-pub struct Qos<'a>(&'a EventRef);
+declare_concrete_event!(Qos);
 impl<'a> Qos<'a> {
     pub fn get(&self) -> (::QOSType, f64, i64, ::ClockTime) {
         unsafe {
@@ -722,7 +737,7 @@ impl<'a> Qos<'a> {
             let mut timestamp = mem::uninitialized();
 
             ffi::gst_event_parse_qos(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut type_,
                 &mut proportion,
                 &mut diff,
@@ -734,7 +749,7 @@ impl<'a> Qos<'a> {
     }
 }
 
-pub struct Seek<'a>(&'a EventRef);
+declare_concrete_event!(Seek);
 impl<'a> Seek<'a> {
     pub fn get(
         &self,
@@ -756,7 +771,7 @@ impl<'a> Seek<'a> {
             let mut stop = mem::uninitialized();
 
             ffi::gst_event_parse_seek(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut rate,
                 &mut fmt,
                 &mut flags,
@@ -778,22 +793,22 @@ impl<'a> Seek<'a> {
     }
 }
 
-pub struct Navigation<'a>(&'a EventRef);
+declare_concrete_event!(Navigation);
 
-pub struct Latency<'a>(&'a EventRef);
+declare_concrete_event!(Latency);
 impl<'a> Latency<'a> {
     pub fn get_latency(&self) -> ::ClockTime {
         unsafe {
             let mut latency = mem::uninitialized();
 
-            ffi::gst_event_parse_latency(self.0.as_mut_ptr(), &mut latency);
+            ffi::gst_event_parse_latency(self.as_mut_ptr(), &mut latency);
 
             from_glib(latency)
         }
     }
 }
 
-pub struct Step<'a>(&'a EventRef);
+declare_concrete_event!(Step);
 impl<'a> Step<'a> {
     pub fn get(&self) -> (GenericFormattedValue, f64, bool, bool) {
         unsafe {
@@ -804,7 +819,7 @@ impl<'a> Step<'a> {
             let mut intermediate = mem::uninitialized();
 
             ffi::gst_event_parse_step(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut fmt,
                 &mut amount,
                 &mut rate,
@@ -822,41 +837,41 @@ impl<'a> Step<'a> {
     }
 }
 
-pub struct Reconfigure<'a>(&'a EventRef);
+declare_concrete_event!(Reconfigure);
 
-pub struct TocSelect<'a>(&'a EventRef);
+declare_concrete_event!(TocSelect);
 impl<'a> TocSelect<'a> {
     pub fn get_uid(&self) -> &'a str {
         unsafe {
             let mut uid = ptr::null_mut();
 
-            ffi::gst_event_parse_toc_select(self.0.as_mut_ptr(), &mut uid);
+            ffi::gst_event_parse_toc_select(self.as_mut_ptr(), &mut uid);
 
             CStr::from_ptr(uid).to_str().unwrap()
         }
     }
 }
 
-pub struct SelectStreams<'a>(&'a EventRef);
+declare_concrete_event!(SelectStreams);
 impl<'a> SelectStreams<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_streams(&self) -> Vec<String> {
         unsafe {
             let mut streams = ptr::null_mut();
 
-            ffi::gst_event_parse_select_streams(self.0.as_mut_ptr(), &mut streams);
+            ffi::gst_event_parse_select_streams(self.as_mut_ptr(), &mut streams);
 
             FromGlibPtrContainer::from_glib_full(streams)
         }
     }
 }
 
-pub struct CustomUpstream<'a>(&'a EventRef);
-pub struct CustomDownstream<'a>(&'a EventRef);
-pub struct CustomDownstreamOob<'a>(&'a EventRef);
-pub struct CustomDownstreamSticky<'a>(&'a EventRef);
-pub struct CustomBoth<'a>(&'a EventRef);
-pub struct CustomBothOob<'a>(&'a EventRef);
+declare_concrete_event!(CustomUpstream);
+declare_concrete_event!(CustomDownstream);
+declare_concrete_event!(CustomDownstreamOob);
+declare_concrete_event!(CustomDownstreamSticky);
+declare_concrete_event!(CustomBoth);
+declare_concrete_event!(CustomBothOob);
 
 macro_rules! event_builder_generic_impl {
     ($new_fn:expr) => {
@@ -1679,7 +1694,8 @@ mod tests {
         let flush_start_evt = Event::new_flush_start().build();
         match flush_start_evt.view() {
             EventView::FlushStart(flush_start_evt) => {
-                assert!(flush_start_evt.0.get_structure().is_none());
+                assert!(!flush_start_evt.is_sticky());
+                assert!(flush_start_evt.get_structure().is_none());
             },
             _ => panic!("flush_start_evt.view() is not an EventView::FlushStart(_)"),
         }
@@ -1689,8 +1705,8 @@ mod tests {
             .build();
         match flush_start_evt.view() {
             EventView::FlushStart(flush_start_evt) => {
-                assert!(flush_start_evt.0.get_structure().is_some());
-                if let Some(other_fields) = flush_start_evt.0.get_structure() {
+                assert!(flush_start_evt.get_structure().is_some());
+                if let Some(other_fields) = flush_start_evt.get_structure() {
                     assert!(other_fields.has_field("extra-field"));
                 }
             },
@@ -1704,8 +1720,8 @@ mod tests {
         match flush_stop_evt.view() {
             EventView::FlushStop(flush_stop_evt) => {
                 assert_eq!(flush_stop_evt.get_reset_time(), true);
-                assert!(flush_stop_evt.0.get_structure().is_some());
-                if let Some(other_fields) = flush_stop_evt.0.get_structure() {
+                assert!(flush_stop_evt.get_structure().is_some());
+                if let Some(other_fields) = flush_stop_evt.get_structure() {
                     assert!(other_fields.has_field("extra-field"));
                 }
             }

--- a/gstreamer/src/event.rs
+++ b/gstreamer/src/event.rs
@@ -873,27 +873,64 @@ declare_concrete_event!(CustomDownstreamSticky);
 declare_concrete_event!(CustomBoth);
 declare_concrete_event!(CustomBothOob);
 
+struct EventBuilder<'a> {
+    seqnum: Option<Seqnum>,
+    running_time_offset: Option<i64>,
+    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+}
+
+impl<'a> EventBuilder<'a> {
+    fn new() -> Self {
+        Self {
+            seqnum: None,
+            running_time_offset: None,
+            other_fields: Vec::new()
+        }
+    }
+
+    fn seqnum(self, seqnum: Seqnum) -> Self {
+        Self {
+            seqnum: Some(seqnum),
+            .. self
+        }
+    }
+
+    fn running_time_offset(self, running_time_offset: i64) -> Self {
+        Self {
+            running_time_offset: Some(running_time_offset),
+            .. self
+        }
+    }
+
+    fn other_fields(self, other_fields: &[(&'a str, &'a ToSendValue)]) -> Self {
+        Self {
+            other_fields: self.other_fields.iter().cloned()
+                .chain(other_fields.iter().cloned())
+                .collect(),
+            .. self
+        }
+    }
+}
+
 macro_rules! event_builder_generic_impl {
     ($new_fn:expr) => {
         pub fn seqnum(self, seqnum: Seqnum) -> Self {
             Self {
-                seqnum: Some(seqnum),
+                builder: self.builder.seqnum(seqnum),
                 .. self
             }
         }
 
         pub fn running_time_offset(self, running_time_offset: i64) -> Self {
             Self {
-                running_time_offset: Some(running_time_offset),
+                builder: self.builder.running_time_offset(running_time_offset),
                 .. self
             }
         }
 
         pub fn other_fields(self, other_fields: &[(&'a str, &'a ToSendValue)]) -> Self {
             Self {
-                other_fields: self.other_fields.iter().cloned()
-                    .chain(other_fields.iter().cloned())
-                    .collect(),
+                builder: self.builder.other_fields(other_fields),
                 .. self
             }
         }
@@ -902,20 +939,20 @@ macro_rules! event_builder_generic_impl {
             assert_initialized_main_thread!();
             unsafe {
                 let event = $new_fn(&mut self);
-                if let Some(seqnum) = self.seqnum {
+                if let Some(seqnum) = self.builder.seqnum {
                     ffi::gst_event_set_seqnum(event, seqnum.to_glib());
                 }
 
-                if let Some(running_time_offset) = self.running_time_offset {
+                if let Some(running_time_offset) = self.builder.running_time_offset {
                     ffi::gst_event_set_running_time_offset(event, running_time_offset);
                 }
 
-                if !self.other_fields.is_empty() {
+                if !self.builder.other_fields.is_empty() {
                     let s = StructureRef::from_glib_borrow_mut(
                         ffi::gst_event_writable_structure(event)
                     );
 
-                    for (k, v) in self.other_fields {
+                    for (k, v) in self.builder.other_fields {
                         s.set_value(k, v.to_send_value());
                     }
                 }
@@ -927,17 +964,13 @@ macro_rules! event_builder_generic_impl {
 }
 
 pub struct FlushStartBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
 }
 impl<'a> FlushStartBuilder<'a> {
     fn new() -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
         }
     }
 
@@ -945,18 +978,14 @@ impl<'a> FlushStartBuilder<'a> {
 }
 
 pub struct FlushStopBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     reset_time: bool,
 }
 impl<'a> FlushStopBuilder<'a> {
     fn new(reset_time: bool) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             reset_time: reset_time,
         }
     }
@@ -965,9 +994,7 @@ impl<'a> FlushStopBuilder<'a> {
 }
 
 pub struct StreamStartBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     stream_id: &'a str,
     flags: Option<::StreamFlags>,
     group_id: Option<GroupId>,
@@ -976,9 +1003,7 @@ impl<'a> StreamStartBuilder<'a> {
     fn new(stream_id: &'a str) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             stream_id: stream_id,
             flags: None,
             group_id: None,
@@ -1012,18 +1037,14 @@ impl<'a> StreamStartBuilder<'a> {
 }
 
 pub struct CapsBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     caps: &'a ::Caps,
 }
 impl<'a> CapsBuilder<'a> {
     fn new(caps: &'a ::Caps) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             caps: caps,
         }
     }
@@ -1032,18 +1053,14 @@ impl<'a> CapsBuilder<'a> {
 }
 
 pub struct SegmentBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     segment: &'a ::Segment,
 }
 impl<'a> SegmentBuilder<'a> {
     fn new(segment: &'a ::Segment) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             segment: segment,
         }
     }
@@ -1053,9 +1070,7 @@ impl<'a> SegmentBuilder<'a> {
 
 #[cfg(any(feature = "v1_10", feature = "dox"))]
 pub struct StreamCollectionBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     stream_collection: &'a ::StreamCollection,
 }
 #[cfg(any(feature = "v1_10", feature = "dox"))]
@@ -1063,9 +1078,7 @@ impl<'a> StreamCollectionBuilder<'a> {
     fn new(stream_collection: &'a ::StreamCollection) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             stream_collection: stream_collection,
         }
     }
@@ -1076,18 +1089,14 @@ impl<'a> StreamCollectionBuilder<'a> {
 }
 
 pub struct TagBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     tags: Option<::TagList>,
 }
 impl<'a> TagBuilder<'a> {
     fn new(tags: ::TagList) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             tags: Some(tags),
         }
     }
@@ -1099,9 +1108,7 @@ impl<'a> TagBuilder<'a> {
 }
 
 pub struct BufferSizeBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     minsize: GenericFormattedValue,
     maxsize: GenericFormattedValue,
     async: bool,
@@ -1110,9 +1117,7 @@ impl<'a> BufferSizeBuilder<'a> {
     fn new(minsize: GenericFormattedValue, maxsize: GenericFormattedValue, async: bool) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             minsize: minsize,
             maxsize: maxsize,
             async: async,
@@ -1128,9 +1133,7 @@ impl<'a> BufferSizeBuilder<'a> {
 }
 
 pub struct SinkMessageBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     name: &'a str,
     msg: &'a ::Message,
 }
@@ -1138,9 +1141,7 @@ impl<'a> SinkMessageBuilder<'a> {
     fn new(name: &'a str, msg: &'a ::Message) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             name: name,
             msg: msg,
         }
@@ -1154,9 +1155,7 @@ impl<'a> SinkMessageBuilder<'a> {
 
 #[cfg(any(feature = "v1_10", feature = "dox"))]
 pub struct StreamGroupDoneBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     group_id: GroupId,
 }
 #[cfg(any(feature = "v1_10", feature = "dox"))]
@@ -1164,9 +1163,7 @@ impl<'a> StreamGroupDoneBuilder<'a> {
     fn new(group_id: GroupId) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             group_id: group_id,
         }
     }
@@ -1177,17 +1174,13 @@ impl<'a> StreamGroupDoneBuilder<'a> {
 }
 
 pub struct EosBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
 }
 impl<'a> EosBuilder<'a> {
     fn new() -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
         }
     }
 
@@ -1195,9 +1188,7 @@ impl<'a> EosBuilder<'a> {
 }
 
 pub struct TocBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     toc: &'a ::Toc,
     updated: bool,
 }
@@ -1205,9 +1196,7 @@ impl<'a> TocBuilder<'a> {
     fn new(toc: &'a ::Toc, updated: bool) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             toc: toc,
             updated: updated,
         }
@@ -1220,9 +1209,7 @@ impl<'a> TocBuilder<'a> {
 }
 
 pub struct ProtectionBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     system_id: &'a str,
     data: &'a ::Buffer,
     origin: Option<&'a str>,
@@ -1231,9 +1218,7 @@ impl<'a> ProtectionBuilder<'a> {
     fn new(system_id: &'a str, data: &'a ::Buffer) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             system_id: system_id,
             data: data,
             origin: None,
@@ -1255,18 +1240,14 @@ impl<'a> ProtectionBuilder<'a> {
 }
 
 pub struct SegmentDoneBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     position: GenericFormattedValue,
 }
 impl<'a> SegmentDoneBuilder<'a> {
     fn new(position: GenericFormattedValue) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             position: position,
         }
     }
@@ -1278,9 +1259,7 @@ impl<'a> SegmentDoneBuilder<'a> {
 }
 
 pub struct GapBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     timestamp: ::ClockTime,
     duration: ::ClockTime,
 }
@@ -1288,9 +1267,7 @@ impl<'a> GapBuilder<'a> {
     fn new(timestamp: ::ClockTime, duration: ::ClockTime) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             timestamp: timestamp,
             duration: duration,
         }
@@ -1303,9 +1280,7 @@ impl<'a> GapBuilder<'a> {
 }
 
 pub struct QosBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     type_: ::QOSType,
     proportion: f64,
     diff: i64,
@@ -1315,9 +1290,7 @@ impl<'a> QosBuilder<'a> {
     fn new(type_: ::QOSType, proportion: f64, diff: i64, timestamp: ::ClockTime) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             type_: type_,
             proportion: proportion,
             diff: diff,
@@ -1334,9 +1307,7 @@ impl<'a> QosBuilder<'a> {
 }
 
 pub struct SeekBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     rate: f64,
     flags: ::SeekFlags,
     start_type: ::SeekType,
@@ -1355,9 +1326,7 @@ impl<'a> SeekBuilder<'a> {
     ) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             rate: rate,
             flags: flags,
             start_type,
@@ -1379,18 +1348,14 @@ impl<'a> SeekBuilder<'a> {
 }
 
 pub struct NavigationBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> NavigationBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1405,18 +1370,14 @@ impl<'a> NavigationBuilder<'a> {
 }
 
 pub struct LatencyBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     latency: ::ClockTime,
 }
 impl<'a> LatencyBuilder<'a> {
     fn new(latency: ::ClockTime) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             latency: latency,
         }
     }
@@ -1425,9 +1386,7 @@ impl<'a> LatencyBuilder<'a> {
 }
 
 pub struct StepBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     amount: GenericFormattedValue,
     rate: f64,
     flush: bool,
@@ -1437,9 +1396,7 @@ impl<'a> StepBuilder<'a> {
     fn new(amount: GenericFormattedValue, rate: f64, flush: bool, intermediate: bool) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             amount: amount,
             rate: rate,
             flush: flush,
@@ -1457,17 +1414,13 @@ impl<'a> StepBuilder<'a> {
 }
 
 pub struct ReconfigureBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
 }
 impl<'a> ReconfigureBuilder<'a> {
     fn new() -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
         }
     }
 
@@ -1475,18 +1428,14 @@ impl<'a> ReconfigureBuilder<'a> {
 }
 
 pub struct TocSelectBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     uid: &'a str,
 }
 impl<'a> TocSelectBuilder<'a> {
     fn new(uid: &'a str) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             uid: uid,
         }
     }
@@ -1496,9 +1445,7 @@ impl<'a> TocSelectBuilder<'a> {
 
 #[cfg(any(feature = "v1_10", feature = "dox"))]
 pub struct SelectStreamsBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     streams: &'a [&'a str],
 }
 #[cfg(any(feature = "v1_10", feature = "dox"))]
@@ -1506,9 +1453,7 @@ impl<'a> SelectStreamsBuilder<'a> {
     fn new(streams: &'a [&'a str]) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             streams: streams,
         }
     }
@@ -1519,18 +1464,14 @@ impl<'a> SelectStreamsBuilder<'a> {
 }
 
 pub struct CustomUpstreamBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> CustomUpstreamBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1546,18 +1487,14 @@ impl<'a> CustomUpstreamBuilder<'a> {
 }
 
 pub struct CustomDownstreamBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> CustomDownstreamBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1573,18 +1510,14 @@ impl<'a> CustomDownstreamBuilder<'a> {
 }
 
 pub struct CustomDownstreamOobBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> CustomDownstreamOobBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1602,18 +1535,14 @@ impl<'a> CustomDownstreamOobBuilder<'a> {
 }
 
 pub struct CustomDownstreamStickyBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> CustomDownstreamStickyBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1631,18 +1560,14 @@ impl<'a> CustomDownstreamStickyBuilder<'a> {
 }
 
 pub struct CustomBothBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> CustomBothBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1657,18 +1582,14 @@ impl<'a> CustomBothBuilder<'a> {
 }
 
 pub struct CustomBothOobBuilder<'a> {
-    seqnum: Option<Seqnum>,
-    running_time_offset: Option<i64>,
-    other_fields: Vec<(&'a str, &'a ToSendValue)>,
+    builder: EventBuilder<'a>,
     structure: Option<Structure>,
 }
 impl<'a> CustomBothOobBuilder<'a> {
     fn new(structure: Structure) -> Self {
         skip_assert_initialized!();
         Self {
-            seqnum: None,
-            running_time_offset: None,
-            other_fields: Vec::new(),
+            builder: EventBuilder::new(),
             structure: Some(structure),
         }
     }
@@ -1682,6 +1603,7 @@ impl<'a> CustomBothOobBuilder<'a> {
         ev
     });
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/gstreamer/src/message.rs
+++ b/gstreamer/src/message.rs
@@ -20,6 +20,7 @@ use std::ptr;
 use std::mem;
 use std::fmt;
 use std::ffi::CStr;
+use std::ops::Deref;
 
 use glib;
 use glib::Cast;
@@ -420,15 +421,29 @@ pub enum MessageView<'a> {
     __NonExhaustive,
 }
 
-pub struct Eos<'a>(&'a MessageRef);
+macro_rules! declare_concrete_message(
+    ($name:ident) => {
+        pub struct $name<'a>(&'a MessageRef);
 
-pub struct Error<'a>(&'a MessageRef);
+        impl<'a> Deref for $name<'a> {
+            type Target = MessageRef;
+
+            fn deref(&self) -> &Self::Target {
+                self.0
+            }
+        }
+    }
+);
+
+declare_concrete_message!(Eos);
+
+declare_concrete_message!(Error);
 impl<'a> Error<'a> {
     pub fn get_error(&self) -> glib::Error {
         unsafe {
             let mut error = ptr::null_mut();
 
-            ffi::gst_message_parse_error(self.0.as_mut_ptr(), &mut error, ptr::null_mut());
+            ffi::gst_message_parse_error(self.as_mut_ptr(), &mut error, ptr::null_mut());
 
             from_glib_full(error)
         }
@@ -438,7 +453,7 @@ impl<'a> Error<'a> {
         unsafe {
             let mut debug = ptr::null_mut();
 
-            ffi::gst_message_parse_error(self.0.as_mut_ptr(), ptr::null_mut(), &mut debug);
+            ffi::gst_message_parse_error(self.as_mut_ptr(), ptr::null_mut(), &mut debug);
 
             from_glib_full(debug)
         }
@@ -449,7 +464,7 @@ impl<'a> Error<'a> {
         unsafe {
             let mut details = ptr::null();
 
-            ffi::gst_message_parse_error_details(self.0.as_mut_ptr(), &mut details);
+            ffi::gst_message_parse_error_details(self.as_mut_ptr(), &mut details);
 
             if details.is_null() {
                 None
@@ -460,13 +475,13 @@ impl<'a> Error<'a> {
     }
 }
 
-pub struct Warning<'a>(&'a MessageRef);
+declare_concrete_message!(Warning);
 impl<'a> Warning<'a> {
     pub fn get_error(&self) -> glib::Error {
         unsafe {
             let mut error = ptr::null_mut();
 
-            ffi::gst_message_parse_warning(self.0.as_mut_ptr(), &mut error, ptr::null_mut());
+            ffi::gst_message_parse_warning(self.as_mut_ptr(), &mut error, ptr::null_mut());
 
             from_glib_full(error)
         }
@@ -476,7 +491,7 @@ impl<'a> Warning<'a> {
         unsafe {
             let mut debug = ptr::null_mut();
 
-            ffi::gst_message_parse_warning(self.0.as_mut_ptr(), ptr::null_mut(), &mut debug);
+            ffi::gst_message_parse_warning(self.as_mut_ptr(), ptr::null_mut(), &mut debug);
 
             from_glib_full(debug)
         }
@@ -487,7 +502,7 @@ impl<'a> Warning<'a> {
         unsafe {
             let mut details = ptr::null();
 
-            ffi::gst_message_parse_error_details(self.0.as_mut_ptr(), &mut details);
+            ffi::gst_message_parse_error_details(self.as_mut_ptr(), &mut details);
 
             if details.is_null() {
                 None
@@ -498,13 +513,13 @@ impl<'a> Warning<'a> {
     }
 }
 
-pub struct Info<'a>(&'a MessageRef);
+declare_concrete_message!(Info);
 impl<'a> Info<'a> {
     pub fn get_error(&self) -> glib::Error {
         unsafe {
             let mut error = ptr::null_mut();
 
-            ffi::gst_message_parse_info(self.0.as_mut_ptr(), &mut error, ptr::null_mut());
+            ffi::gst_message_parse_info(self.as_mut_ptr(), &mut error, ptr::null_mut());
 
             from_glib_full(error)
         }
@@ -514,7 +529,7 @@ impl<'a> Info<'a> {
         unsafe {
             let mut debug = ptr::null_mut();
 
-            ffi::gst_message_parse_info(self.0.as_mut_ptr(), ptr::null_mut(), &mut debug);
+            ffi::gst_message_parse_info(self.as_mut_ptr(), ptr::null_mut(), &mut debug);
 
             from_glib_full(debug)
         }
@@ -525,7 +540,7 @@ impl<'a> Info<'a> {
         unsafe {
             let mut details = ptr::null();
 
-            ffi::gst_message_parse_error_details(self.0.as_mut_ptr(), &mut details);
+            ffi::gst_message_parse_error_details(self.as_mut_ptr(), &mut details);
 
             if details.is_null() {
                 None
@@ -536,23 +551,23 @@ impl<'a> Info<'a> {
     }
 }
 
-pub struct Tag<'a>(&'a MessageRef);
+declare_concrete_message!(Tag);
 impl<'a> Tag<'a> {
     pub fn get_tags(&self) -> TagList {
         unsafe {
             let mut tags = ptr::null_mut();
-            ffi::gst_message_parse_tag(self.0.as_mut_ptr(), &mut tags);
+            ffi::gst_message_parse_tag(self.as_mut_ptr(), &mut tags);
             from_glib_full(tags)
         }
     }
 }
 
-pub struct Buffering<'a>(&'a MessageRef);
+declare_concrete_message!(Buffering);
 impl<'a> Buffering<'a> {
     pub fn get_percent(&self) -> i32 {
         unsafe {
             let mut p = mem::uninitialized();
-            ffi::gst_message_parse_buffering(self.0.as_mut_ptr(), &mut p);
+            ffi::gst_message_parse_buffering(self.as_mut_ptr(), &mut p);
             p
         }
     }
@@ -565,7 +580,7 @@ impl<'a> Buffering<'a> {
             let mut buffering_left = mem::uninitialized();
 
             ffi::gst_message_parse_buffering_stats(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut mode,
                 &mut avg_in,
                 &mut avg_out,
@@ -577,14 +592,14 @@ impl<'a> Buffering<'a> {
     }
 }
 
-pub struct StateChanged<'a>(&'a MessageRef);
+declare_concrete_message!(StateChanged);
 impl<'a> StateChanged<'a> {
     pub fn get_old(&self) -> ::State {
         unsafe {
             let mut state = mem::uninitialized();
 
             ffi::gst_message_parse_state_changed(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut state,
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -599,7 +614,7 @@ impl<'a> StateChanged<'a> {
             let mut state = mem::uninitialized();
 
             ffi::gst_message_parse_state_changed(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 ptr::null_mut(),
                 &mut state,
                 ptr::null_mut(),
@@ -614,7 +629,7 @@ impl<'a> StateChanged<'a> {
             let mut state = mem::uninitialized();
 
             ffi::gst_message_parse_state_changed(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 ptr::null_mut(),
                 ptr::null_mut(),
                 &mut state,
@@ -625,9 +640,9 @@ impl<'a> StateChanged<'a> {
     }
 }
 
-pub struct StateDirty<'a>(&'a MessageRef);
+declare_concrete_message!(StateDirty);
 
-pub struct StepDone<'a>(&'a MessageRef);
+declare_concrete_message!(StepDone);
 impl<'a> StepDone<'a> {
     pub fn get(
         &self,
@@ -649,7 +664,7 @@ impl<'a> StepDone<'a> {
             let mut eos = mem::uninitialized();
 
             ffi::gst_message_parse_step_done(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut format,
                 &mut amount,
                 &mut rate,
@@ -671,13 +686,13 @@ impl<'a> StepDone<'a> {
     }
 }
 
-pub struct ClockProvide<'a>(&'a MessageRef);
+declare_concrete_message!(ClockProvide);
 impl<'a> ClockProvide<'a> {
     pub fn get_clock(&self) -> Option<::Clock> {
         let mut clock = ptr::null_mut();
 
         unsafe {
-            ffi::gst_message_parse_clock_provide(self.0.as_mut_ptr(), &mut clock, ptr::null_mut());
+            ffi::gst_message_parse_clock_provide(self.as_mut_ptr(), &mut clock, ptr::null_mut());
 
             from_glib_none(clock)
         }
@@ -687,40 +702,40 @@ impl<'a> ClockProvide<'a> {
         unsafe {
             let mut ready = mem::uninitialized();
 
-            ffi::gst_message_parse_clock_provide(self.0.as_mut_ptr(), ptr::null_mut(), &mut ready);
+            ffi::gst_message_parse_clock_provide(self.as_mut_ptr(), ptr::null_mut(), &mut ready);
 
             from_glib(ready)
         }
     }
 }
 
-pub struct ClockLost<'a>(&'a MessageRef);
+declare_concrete_message!(ClockLost);
 impl<'a> ClockLost<'a> {
     pub fn get_clock(&self) -> Option<::Clock> {
         let mut clock = ptr::null_mut();
 
         unsafe {
-            ffi::gst_message_parse_clock_lost(self.0.as_mut_ptr(), &mut clock);
+            ffi::gst_message_parse_clock_lost(self.as_mut_ptr(), &mut clock);
 
             from_glib_none(clock)
         }
     }
 }
 
-pub struct NewClock<'a>(&'a MessageRef);
+declare_concrete_message!(NewClock);
 impl<'a> NewClock<'a> {
     pub fn get_clock(&self) -> Option<::Clock> {
         let mut clock = ptr::null_mut();
 
         unsafe {
-            ffi::gst_message_parse_new_clock(self.0.as_mut_ptr(), &mut clock);
+            ffi::gst_message_parse_new_clock(self.as_mut_ptr(), &mut clock);
 
             from_glib_none(clock)
         }
     }
 }
 
-pub struct StructureChange<'a>(&'a MessageRef);
+declare_concrete_message!(StructureChange);
 impl<'a> StructureChange<'a> {
     pub fn get(&self) -> (::StructureChangeType, ::Element, bool) {
         unsafe {
@@ -729,7 +744,7 @@ impl<'a> StructureChange<'a> {
             let mut busy = mem::uninitialized();
 
             ffi::gst_message_parse_structure_change(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut type_,
                 &mut owner,
                 &mut busy,
@@ -740,14 +755,14 @@ impl<'a> StructureChange<'a> {
     }
 }
 
-pub struct StreamStatus<'a>(&'a MessageRef);
+declare_concrete_message!(StreamStatus);
 impl<'a> StreamStatus<'a> {
     pub fn get(&self) -> (::StreamStatusType, ::Element) {
         unsafe {
             let mut type_ = mem::uninitialized();
             let mut owner = ptr::null_mut();
 
-            ffi::gst_message_parse_stream_status(self.0.as_mut_ptr(), &mut type_, &mut owner);
+            ffi::gst_message_parse_stream_status(self.as_mut_ptr(), &mut type_, &mut owner);
 
             (from_glib(type_), from_glib_none(owner))
         }
@@ -755,78 +770,76 @@ impl<'a> StreamStatus<'a> {
 
     pub fn get_stream_status_object(&self) -> Option<glib::Value> {
         unsafe {
-            let value = ffi::gst_message_get_stream_status_object(self.0.as_mut_ptr());
+            let value = ffi::gst_message_get_stream_status_object(self.as_mut_ptr());
 
             from_glib_none(value)
         }
     }
 }
 
-pub struct Application<'a>(&'a MessageRef);
+declare_concrete_message!(Application);
 
-pub struct Element<'a>(&'a MessageRef);
+declare_concrete_message!(Element);
 
-pub struct SegmentStart<'a>(&'a MessageRef);
+declare_concrete_message!(SegmentStart);
 impl<'a> SegmentStart<'a> {
     pub fn get(&self) -> GenericFormattedValue {
         unsafe {
             let mut format = mem::uninitialized();
             let mut position = mem::uninitialized();
 
-            ffi::gst_message_parse_segment_start(self.0.as_mut_ptr(), &mut format, &mut position);
+            ffi::gst_message_parse_segment_start(self.as_mut_ptr(), &mut format, &mut position);
 
             GenericFormattedValue::new(from_glib(format), position)
         }
     }
 }
 
-pub struct SegmentDone<'a>(&'a MessageRef);
+declare_concrete_message!(SegmentDone);
 impl<'a> SegmentDone<'a> {
     pub fn get(&self) -> GenericFormattedValue {
         unsafe {
             let mut format = mem::uninitialized();
             let mut position = mem::uninitialized();
 
-            ffi::gst_message_parse_segment_done(self.0.as_mut_ptr(), &mut format, &mut position);
+            ffi::gst_message_parse_segment_done(self.as_mut_ptr(), &mut format, &mut position);
 
             GenericFormattedValue::new(from_glib(format), position)
         }
     }
 }
 
-pub struct DurationChanged<'a>(&'a MessageRef);
+declare_concrete_message!(DurationChanged);
+declare_concrete_message!(Latency);
+declare_concrete_message!(AsyncStart);
 
-pub struct Latency<'a>(&'a MessageRef);
-
-pub struct AsyncStart<'a>(&'a MessageRef);
-
-pub struct AsyncDone<'a>(&'a MessageRef);
+declare_concrete_message!(AsyncDone);
 impl<'a> AsyncDone<'a> {
     pub fn get_running_time(&self) -> ::ClockTime {
         unsafe {
             let mut running_time = mem::uninitialized();
 
-            ffi::gst_message_parse_async_done(self.0.as_mut_ptr(), &mut running_time);
+            ffi::gst_message_parse_async_done(self.as_mut_ptr(), &mut running_time);
 
             from_glib(running_time)
         }
     }
 }
 
-pub struct RequestState<'a>(&'a MessageRef);
+declare_concrete_message!(RequestState);
 impl<'a> RequestState<'a> {
     pub fn get_requested_state(&self) -> ::State {
         unsafe {
             let mut state = mem::uninitialized();
 
-            ffi::gst_message_parse_request_state(self.0.as_mut_ptr(), &mut state);
+            ffi::gst_message_parse_request_state(self.as_mut_ptr(), &mut state);
 
             from_glib(state)
         }
     }
 }
 
-pub struct StepStart<'a>(&'a MessageRef);
+declare_concrete_message!(StepStart);
 impl<'a> StepStart<'a> {
     pub fn get(&self) -> (bool, GenericFormattedValue, f64, bool, bool) {
         unsafe {
@@ -838,7 +851,7 @@ impl<'a> StepStart<'a> {
             let mut intermediate = mem::uninitialized();
 
             ffi::gst_message_parse_step_start(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut active,
                 &mut format,
                 &mut amount,
@@ -858,7 +871,7 @@ impl<'a> StepStart<'a> {
     }
 }
 
-pub struct Qos<'a>(&'a MessageRef);
+declare_concrete_message!(Qos);
 impl<'a> Qos<'a> {
     pub fn get(&self) -> (bool, ::ClockTime, ::ClockTime, ::ClockTime, ::ClockTime) {
         unsafe {
@@ -869,7 +882,7 @@ impl<'a> Qos<'a> {
             let mut duration = mem::uninitialized();
 
             ffi::gst_message_parse_qos(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut live,
                 &mut running_time,
                 &mut stream_time,
@@ -894,7 +907,7 @@ impl<'a> Qos<'a> {
             let mut quality = mem::uninitialized();
 
             ffi::gst_message_parse_qos_values(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut jitter,
                 &mut proportion,
                 &mut quality,
@@ -911,7 +924,7 @@ impl<'a> Qos<'a> {
             let mut dropped = mem::uninitialized();
 
             ffi::gst_message_parse_qos_stats(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut format,
                 &mut processed,
                 &mut dropped,
@@ -925,7 +938,7 @@ impl<'a> Qos<'a> {
     }
 }
 
-pub struct Progress<'a>(&'a MessageRef);
+declare_concrete_message!(Progress);
 impl<'a> Progress<'a> {
     pub fn get(&self) -> (::ProgressType, &'a str, &'a str) {
         unsafe {
@@ -933,7 +946,7 @@ impl<'a> Progress<'a> {
             let mut code = ptr::null_mut();
             let mut text = ptr::null_mut();
 
-            ffi::gst_message_parse_progress(self.0.as_mut_ptr(), &mut type_, &mut code, &mut text);
+            ffi::gst_message_parse_progress(self.as_mut_ptr(), &mut type_, &mut code, &mut text);
 
             let code = CStr::from_ptr(code).to_str().unwrap();
             let text = CStr::from_ptr(text).to_str().unwrap();
@@ -943,39 +956,39 @@ impl<'a> Progress<'a> {
     }
 }
 
-pub struct Toc<'a>(&'a MessageRef);
+declare_concrete_message!(Toc);
 impl<'a> Toc<'a> {
     pub fn get_toc(&self) -> (::Toc, bool) {
         unsafe {
             let mut toc = ptr::null_mut();
             let mut updated = mem::uninitialized();
-            ffi::gst_message_parse_toc(self.0.as_mut_ptr(), &mut toc, &mut updated);
+            ffi::gst_message_parse_toc(self.as_mut_ptr(), &mut toc, &mut updated);
             (from_glib_full(toc), from_glib(updated))
         }
     }
 }
 
-pub struct ResetTime<'a>(&'a MessageRef);
+declare_concrete_message!(ResetTime);
 impl<'a> ResetTime<'a> {
     pub fn get_running_time(&self) -> ::ClockTime {
         unsafe {
             let mut running_time = mem::uninitialized();
 
-            ffi::gst_message_parse_reset_time(self.0.as_mut_ptr(), &mut running_time);
+            ffi::gst_message_parse_reset_time(self.as_mut_ptr(), &mut running_time);
 
             from_glib(running_time)
         }
     }
 }
 
-pub struct StreamStart<'a>(&'a MessageRef);
+declare_concrete_message!(StreamStart);
 impl<'a> StreamStart<'a> {
     pub fn get_group_id(&self) -> Option<GroupId> {
         unsafe {
             let mut group_id = mem::uninitialized();
 
             if from_glib(ffi::gst_message_parse_group_id(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut group_id,
             )) {
                 Some(from_glib(group_id))
@@ -986,57 +999,57 @@ impl<'a> StreamStart<'a> {
     }
 }
 
-pub struct NeedContext<'a>(&'a MessageRef);
+declare_concrete_message!(NeedContext);
 impl<'a> NeedContext<'a> {
     pub fn get_context_type(&self) -> &str {
         unsafe {
             let mut context_type = ptr::null();
 
-            ffi::gst_message_parse_context_type(self.0.as_mut_ptr(), &mut context_type);
+            ffi::gst_message_parse_context_type(self.as_mut_ptr(), &mut context_type);
 
             CStr::from_ptr(context_type).to_str().unwrap()
         }
     }
 }
 
-pub struct HaveContext<'a>(&'a MessageRef);
+declare_concrete_message!(HaveContext);
 impl<'a> HaveContext<'a> {
     pub fn get_context(&self) -> ::Context {
         unsafe {
             let mut context = ptr::null_mut();
-            ffi::gst_message_parse_have_context(self.0.as_mut_ptr(), &mut context);
+            ffi::gst_message_parse_have_context(self.as_mut_ptr(), &mut context);
             from_glib_full(context)
         }
     }
 }
 
-pub struct DeviceAdded<'a>(&'a MessageRef);
+declare_concrete_message!(DeviceAdded);
 impl<'a> DeviceAdded<'a> {
     pub fn get_device(&self) -> ::Device {
         unsafe {
             let mut device = ptr::null_mut();
 
-            ffi::gst_message_parse_device_added(self.0.as_mut_ptr(), &mut device);
+            ffi::gst_message_parse_device_added(self.as_mut_ptr(), &mut device);
 
             from_glib_none(device)
         }
     }
 }
 
-pub struct DeviceRemoved<'a>(&'a MessageRef);
+declare_concrete_message!(DeviceRemoved);
 impl<'a> DeviceRemoved<'a> {
     pub fn get_device(&self) -> ::Device {
         unsafe {
             let mut device = ptr::null_mut();
 
-            ffi::gst_message_parse_device_removed(self.0.as_mut_ptr(), &mut device);
+            ffi::gst_message_parse_device_removed(self.as_mut_ptr(), &mut device);
 
             from_glib_none(device)
         }
     }
 }
 
-pub struct PropertyNotify<'a>(&'a MessageRef);
+declare_concrete_message!(PropertyNotify);
 impl<'a> PropertyNotify<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get(&self) -> (Object, &str, Option<&'a ::Value>) {
@@ -1046,7 +1059,7 @@ impl<'a> PropertyNotify<'a> {
             let mut value = ptr::null();
 
             ffi::gst_message_parse_property_notify(
-                self.0.as_mut_ptr(),
+                self.as_mut_ptr(),
                 &mut object,
                 &mut property_name,
                 &mut value,
@@ -1065,27 +1078,28 @@ impl<'a> PropertyNotify<'a> {
     }
 }
 
-pub struct StreamCollection<'a>(&'a MessageRef);
+declare_concrete_message!(StreamCollection);
 impl<'a> StreamCollection<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_stream_collection(&self) -> ::StreamCollection {
         unsafe {
             let mut collection = ptr::null_mut();
 
-            ffi::gst_message_parse_stream_collection(self.0.as_mut_ptr(), &mut collection);
+            ffi::gst_message_parse_stream_collection(self.as_mut_ptr(), &mut collection);
 
             from_glib_full(collection)
         }
     }
 }
-pub struct StreamsSelected<'a>(&'a MessageRef);
+
+declare_concrete_message!(StreamsSelected);
 impl<'a> StreamsSelected<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_stream_collection(&self) -> ::StreamCollection {
         unsafe {
             let mut collection = ptr::null_mut();
 
-            ffi::gst_message_parse_streams_selected(self.0.as_mut_ptr(), &mut collection);
+            ffi::gst_message_parse_streams_selected(self.as_mut_ptr(), &mut collection);
 
             from_glib_full(collection)
         }
@@ -1094,12 +1108,12 @@ impl<'a> StreamsSelected<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_streams(&self) -> Vec<::Stream> {
         unsafe {
-            let n = ffi::gst_message_streams_selected_get_size(self.0.as_mut_ptr());
+            let n = ffi::gst_message_streams_selected_get_size(self.as_mut_ptr());
 
             (0..n)
                 .map(|i| {
                     from_glib_full(ffi::gst_message_streams_selected_get_stream(
-                        self.0.as_mut_ptr(),
+                        self.as_mut_ptr(),
                         i,
                     ))
                 })
@@ -1108,12 +1122,12 @@ impl<'a> StreamsSelected<'a> {
     }
 }
 
-pub struct Redirect<'a>(&'a MessageRef);
+declare_concrete_message!(Redirect);
 impl<'a> Redirect<'a> {
     #[cfg(any(feature = "v1_10", feature = "dox"))]
     pub fn get_entries(&self) -> Vec<(&str, Option<TagList>, Option<&StructureRef>)> {
         unsafe {
-            let n = ffi::gst_message_get_num_redirect_entries(self.0.as_mut_ptr());
+            let n = ffi::gst_message_get_num_redirect_entries(self.as_mut_ptr());
 
             (0..n)
                 .map(|i| {
@@ -1122,7 +1136,7 @@ impl<'a> Redirect<'a> {
                     let mut structure = ptr::null();
 
                     ffi::gst_message_parse_redirect_entry(
-                        self.0.as_mut_ptr(),
+                        self.as_mut_ptr(),
                         i,
                         &mut location,
                         &mut tags,
@@ -2459,10 +2473,13 @@ mod tests {
         ::init().unwrap();
 
         // Message without arguments
-        let eos_msg = Message::new_eos().build();
+        let eos_msg = Message::new_eos()
+            .seqnum(Seqnum(1))
+            .build();
         match eos_msg.view() {
             MessageView::Eos(eos_msg) => {
-                assert!(eos_msg.0.get_structure().is_none());
+                assert_eq!(eos_msg.get_seqnum(), Seqnum(1));
+                assert!(eos_msg.get_structure().is_none());
             },
             _ => panic!("eos_msg.view() is not a MessageView::Eos(_)"),
         }

--- a/tutorials/src/bin/basic-tutorial-1.rs
+++ b/tutorials/src/bin/basic-tutorial-1.rs
@@ -27,7 +27,7 @@ fn tutorial_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error from {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );

--- a/tutorials/src/bin/basic-tutorial-2.rs
+++ b/tutorials/src/bin/basic-tutorial-2.rs
@@ -40,7 +40,7 @@ fn tutorial_main() {
             MessageView::Error(err) => {
                 eprintln!(
                     "Error received from element {:?}: {}",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error()
                 );
                 eprintln!("Debugging information: {:?}", err.get_debug());

--- a/tutorials/src/bin/basic-tutorial-3.rs
+++ b/tutorials/src/bin/basic-tutorial-3.rs
@@ -93,18 +93,18 @@ fn tutorial_main() {
             MessageView::Error(err) => {
                 eprintln!(
                     "Error received from element {:?} {}",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error()
                 );
                 eprintln!("Debugging information: {:?}", err.get_debug());
                 break;
             }
-            MessageView::StateChanged(s) => {
-                if msg.get_src().map(|s| s == pipeline).unwrap_or(false) {
+            MessageView::StateChanged(state_changed) => {
+                if state_changed.get_src().map(|s| s == pipeline).unwrap_or(false) {
                     println!(
                         "Pipeline state changed from {:?} to {:?}",
-                        s.get_old(),
-                        s.get_current()
+                        state_changed.get_old(),
+                        state_changed.get_current()
                     );
                 }
             }

--- a/tutorials/src/bin/basic-tutorial-4.rs
+++ b/tutorials/src/bin/basic-tutorial-4.rs
@@ -100,7 +100,7 @@ fn handle_message(custom_data: &mut CustomData, msg: &gst::GstRc<gst::MessageRef
         MessageView::Error(err) => {
             println!(
                 "Error received from element {:?}: {} ({:?})",
-                msg.get_src().map(|s| s.get_path_string()),
+                err.get_src().map(|s| s.get_path_string()),
                 err.get_error(),
                 err.get_debug()
             );
@@ -114,12 +114,12 @@ fn handle_message(custom_data: &mut CustomData, msg: &gst::GstRc<gst::MessageRef
             // The duration has changed, mark the current one as invalid
             custom_data.duration = gst::CLOCK_TIME_NONE;
         }
-        MessageView::StateChanged(state) => if msg.get_src()
+        MessageView::StateChanged(state_changed) => if state_changed.get_src()
             .map(|s| s == custom_data.playbin)
             .unwrap_or(false)
         {
-            let new_state = state.get_current();
-            let old_state = state.get_old();
+            let new_state = state_changed.get_current();
+            let old_state = state_changed.get_old();
 
             println!(
                 "Pipeline state changed from {:?} to {:?}",

--- a/tutorials/src/bin/basic-tutorial-5.rs
+++ b/tutorials/src/bin/basic-tutorial-5.rs
@@ -238,8 +238,8 @@ mod tutorial5 {
             .get_bus()
             .unwrap()
             .connect_message(move |_, msg| match msg.view() {
-                gst::MessageView::Application(_) => {
-                    if msg.get_structure().map(|s| s.get_name()) == Some("tags-changed") {
+                gst::MessageView::Application(application) => {
+                    if application.get_structure().map(|s| s.get_name()) == Some("tags-changed") {
                         analyze_streams(&pipeline, &textbuf);
                     }
                 }
@@ -339,16 +339,16 @@ mod tutorial5 {
                 gst::MessageView::Error(err) => {
                     println!(
                         "Error from {:?}: {} ({:?})",
-                        msg.get_src().map(|s| s.get_path_string()),
+                        err.get_src().map(|s| s.get_path_string()),
                         err.get_error(),
                         err.get_debug()
                     );
                 }
                 // This is called when the pipeline changes states. We use it to
                 // keep track of the current state.
-                gst::MessageView::StateChanged(view) => {
-                    if msg.get_src().map(|s| s == pipeline).unwrap_or(false) {
-                        println!("State set to {:?}", view.get_current());
+                gst::MessageView::StateChanged(state_changed) => {
+                    if state_changed.get_src().map(|s| s == pipeline).unwrap_or(false) {
+                        println!("State set to {:?}", state_changed.get_current());
                     }
                 }
                 _ => (),

--- a/tutorials/src/bin/basic-tutorial-6.rs
+++ b/tutorials/src/bin/basic-tutorial-6.rs
@@ -126,7 +126,7 @@ fn tutorial_main() {
             MessageView::Error(err) => {
                 println!(
                     "Error received from element {:?}: {} ({:?})",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error(),
                     err.get_debug()
                 );
@@ -136,11 +136,11 @@ fn tutorial_main() {
                 println!("End-Of-Stream reached.");
                 break;
             }
-            MessageView::StateChanged(state) =>
+            MessageView::StateChanged(state_changed) =>
                 // We are only interested in state-changed messages from the pipeline
-                if msg.get_src().map(|s| s == pipeline).unwrap_or(false) {
-                    let new_state = state.get_current();
-                    let old_state = state.get_old();
+                if state_changed.get_src().map(|s| s == pipeline).unwrap_or(false) {
+                    let new_state = state_changed.get_current();
+                    let old_state = state_changed.get_old();
 
                     println!(
                         "Pipeline state changed from {:?} to {:?}",

--- a/tutorials/src/bin/basic-tutorial-7.rs
+++ b/tutorials/src/bin/basic-tutorial-7.rs
@@ -74,7 +74,7 @@ fn tutorial_main() {
             MessageView::Error(err) => {
                 eprintln!(
                     "Error received from element {:?}: {}",
-                    msg.get_src().map(|s| s.get_path_string()),
+                    err.get_src().map(|s| s.get_path_string()),
                     err.get_error()
                 );
                 eprintln!("Debugging information: {:?}", err.get_debug());

--- a/tutorials/src/bin/basic-tutorial-8.rs
+++ b/tutorials/src/bin/basic-tutorial-8.rs
@@ -242,7 +242,7 @@ fn main() {
             let main_loop = &main_loop_clone;
             eprintln!(
                 "Error received from element {:?}: {}",
-                msg.get_src().map(|s| s.get_path_string()),
+                err.get_src().map(|s| s.get_path_string()),
                 err.get_error()
             );
             eprintln!("Debugging information: {:?}", err.get_debug());


### PR DESCRIPTION
Implement `deref` for concrete derivatives of `Event`, `Message` and `Query`. This allows accessing generic methods such as `is_sticky` for events or `get_src` for messages and `get_structure` for all.

This is also an opportunity to factorize common attributes in generic builders for events and messages.