### PR TITLE
Query: proposal to solve the deref/deref_mut issue

### DIFF
--- a/examples/src/bin/queries.rs
+++ b/examples/src/bin/queries.rs
@@ -30,7 +30,7 @@ fn example_main() {
         //let pos = pipeline.query_position(gst::Format::Time).unwrap_or(-1);
         //let dur = pipeline.query_duration(gst::Format::Time).unwrap_or(-1);
         let pos = {
-            let mut q = gst::QueryRef::new_position(gst::Format::Time);
+            let mut q = gst::Query::new_position(gst::Format::Time);
             if pipeline.query(&mut q) {
                 Some(q.get_result())
             } else {
@@ -40,7 +40,7 @@ fn example_main() {
             .unwrap();
 
         let dur = {
-            let mut q = gst::QueryRef::new_duration(gst::Format::Time);
+            let mut q = gst::Query::new_duration(gst::Format::Time);
             if pipeline.query(&mut q) {
                 Some(q.get_result())
             } else {

--- a/examples/src/bin/queries.rs
+++ b/examples/src/bin/queries.rs
@@ -30,7 +30,7 @@ fn example_main() {
         //let pos = pipeline.query_position(gst::Format::Time).unwrap_or(-1);
         //let dur = pipeline.query_duration(gst::Format::Time).unwrap_or(-1);
         let pos = {
-            let mut q = gst::Query::new_position(gst::Format::Time);
+            let mut q = gst::QueryRef::new_position(gst::Format::Time);
             if pipeline.query(&mut q) {
                 Some(q.get_result())
             } else {
@@ -40,7 +40,7 @@ fn example_main() {
             .unwrap();
 
         let dur = {
-            let mut q = gst::Query::new_duration(gst::Format::Time);
+            let mut q = gst::QueryRef::new_duration(gst::Format::Time);
             if pipeline.query(&mut q) {
                 Some(q.get_result())
             } else {

--- a/examples/src/bin/queries.rs
+++ b/examples/src/bin/queries.rs
@@ -25,19 +25,14 @@ fn example_main() {
 
     let pipeline_clone = pipeline.clone();
     glib::timeout_add_seconds(1, move || {
-        use gst::QueryView;
-
         let pipeline = &pipeline_clone;
 
         //let pos = pipeline.query_position(gst::Format::Time).unwrap_or(-1);
         //let dur = pipeline.query_duration(gst::Format::Time).unwrap_or(-1);
         let pos = {
             let mut q = gst::Query::new_position(gst::Format::Time);
-            if pipeline.query(q.get_mut().unwrap()) {
-                match q.view() {
-                    QueryView::Position(ref p) => Some(p.get_result()),
-                    _ => None,
-                }
+            if pipeline.query(&mut q) {
+                Some(q.get_result())
             } else {
                 None
             }
@@ -46,11 +41,8 @@ fn example_main() {
 
         let dur = {
             let mut q = gst::Query::new_duration(gst::Format::Time);
-            if pipeline.query(q.get_mut().unwrap()) {
-                match q.view() {
-                    QueryView::Duration(ref p) => Some(p.get_result()),
-                    _ => None,
-                }
+            if pipeline.query(&mut q) {
+                Some(q.get_result())
             } else {
                 None
             }

--- a/gstreamer/src/element.rs
+++ b/gstreamer/src/element.rs
@@ -12,7 +12,7 @@ use glib;
 use glib::IsA;
 use glib::translate::{from_glib, from_glib_full, from_glib_none, FromGlib, FromGlibPtrContainer,
                       ToGlib, ToGlibPtr};
-use QueryRef;
+use Query;
 use Event;
 use Pad;
 use PadTemplate;
@@ -85,7 +85,7 @@ impl FromGlib<libc::c_ulong> for NotifyWatchId {
 }
 
 pub trait ElementExtManual {
-    fn query(&self, query: &mut QueryRef) -> bool;
+    fn query(&self, query: &mut Query) -> bool;
 
     fn send_event(&self, event: Event) -> bool;
 
@@ -177,7 +177,7 @@ pub trait ElementExtManual {
 }
 
 impl<O: IsA<Element>> ElementExtManual for O {
-    fn query(&self, query: &mut QueryRef) -> bool {
+    fn query(&self, query: &mut Query) -> bool {
         unsafe {
             from_glib(ffi::gst_element_query(
                 self.to_glib_none().0,

--- a/gstreamer/src/element.rs
+++ b/gstreamer/src/element.rs
@@ -12,7 +12,7 @@ use glib;
 use glib::IsA;
 use glib::translate::{from_glib, from_glib_full, from_glib_none, FromGlib, FromGlibPtrContainer,
                       ToGlib, ToGlibPtr};
-use Query;
+use QueryRef;
 use Event;
 use Pad;
 use PadTemplate;
@@ -20,7 +20,6 @@ use Format;
 use GenericFormattedValue;
 use FormattedValue;
 use SpecificFormattedValue;
-use miniobject::MiniObject;
 
 use std::ffi::CStr;
 use std::mem;
@@ -85,7 +84,7 @@ impl FromGlib<libc::c_ulong> for NotifyWatchId {
 }
 
 pub trait ElementExtManual {
-    fn query(&self, query: &mut Query) -> bool;
+    fn query(&self, query: &mut QueryRef) -> bool;
 
     fn send_event(&self, event: Event) -> bool;
 
@@ -177,7 +176,7 @@ pub trait ElementExtManual {
 }
 
 impl<O: IsA<Element>> ElementExtManual for O {
-    fn query(&self, query: &mut Query) -> bool {
+    fn query(&self, query: &mut QueryRef) -> bool {
         unsafe {
             from_glib(ffi::gst_element_query(
                 self.to_glib_none().0,

--- a/gstreamer/src/lib.rs
+++ b/gstreamer/src/lib.rs
@@ -84,7 +84,7 @@ pub use sample::{Sample, SampleRef};
 pub mod bufferlist;
 pub use bufferlist::{BufferList, BufferListRef};
 pub mod query;
-pub use query::{Query, QueryView};
+pub use query::{Query, QueryRc, QueryView, QueryWrapper};
 pub mod event;
 pub use event::{Event, EventRef, EventView, GroupId, Seqnum, GROUP_ID_INVALID, SEQNUM_INVALID};
 pub mod context;

--- a/gstreamer/src/lib.rs
+++ b/gstreamer/src/lib.rs
@@ -84,7 +84,7 @@ pub use sample::{Sample, SampleRef};
 pub mod bufferlist;
 pub use bufferlist::{BufferList, BufferListRef};
 pub mod query;
-pub use query::{Query, QueryRef, QueryView};
+pub use query::{Query, QueryView};
 pub mod event;
 pub use event::{Event, EventRef, EventView, GroupId, Seqnum, GROUP_ID_INVALID, SEQNUM_INVALID};
 pub mod context;

--- a/gstreamer/src/lib.rs
+++ b/gstreamer/src/lib.rs
@@ -84,7 +84,7 @@ pub use sample::{Sample, SampleRef};
 pub mod bufferlist;
 pub use bufferlist::{BufferList, BufferListRef};
 pub mod query;
-pub use query::{Query, QueryRc, QueryView, QueryWrapper};
+pub use query::{Query, QueryRef, QueryView};
 pub mod event;
 pub use event::{Event, EventRef, EventView, GroupId, Seqnum, GROUP_ID_INVALID, SEQNUM_INVALID};
 pub mod context;

--- a/gstreamer/src/query.rs
+++ b/gstreamer/src/query.rs
@@ -15,7 +15,7 @@ use std::ptr;
 use std::mem;
 use std::fmt;
 use std::ffi::CStr;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use glib;
 use glib::translate::{from_glib, from_glib_full, ToGlib, ToGlibPtr};
@@ -33,92 +33,148 @@ unsafe impl MiniObject for QueryRef {
 }
 
 impl GstRc<QueryRef> {
-    pub fn new_position(fmt: ::Format) -> Self {
+    pub fn new_position(fmt: ::Format) -> Position {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_position(fmt.to_glib())) }
+        Position(
+            unsafe { from_glib_full(ffi::gst_query_new_position(fmt.to_glib())) }
+        )
     }
 
-    pub fn new_duration(fmt: ::Format) -> Self {
+    pub fn new_duration(fmt: ::Format) -> Duration {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_duration(fmt.to_glib())) }
+        Duration(
+            unsafe { from_glib_full(ffi::gst_query_new_duration(fmt.to_glib())) }
+        )
     }
 
-    pub fn new_latency() -> Self {
+    pub fn new_latency() -> Latency {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_latency()) }
+        Latency(
+            unsafe { from_glib_full(ffi::gst_query_new_latency()) }
+        )
     }
 
-    pub fn new_seeking(fmt: ::Format) -> Self {
+    pub fn new_seeking(fmt: ::Format) -> Seeking {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_seeking(fmt.to_glib())) }
+        Seeking(
+            unsafe { from_glib_full(ffi::gst_query_new_seeking(fmt.to_glib())) }
+        )
     }
 
-    pub fn new_segment(fmt: ::Format) -> Self {
+    pub fn new_segment(fmt: ::Format) -> Segment {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_segment(fmt.to_glib())) }
+        Segment(
+            unsafe { from_glib_full(ffi::gst_query_new_segment(fmt.to_glib())) }
+        )
     }
 
-    pub fn new_convert<V: Into<GenericFormattedValue>>(value: V, dest_fmt: ::Format) -> Self {
+    pub fn new_convert<V: Into<GenericFormattedValue>>(value: V, dest_fmt: ::Format) -> Convert {
         assert_initialized_main_thread!();
         let value = value.into();
-        unsafe {
-            from_glib_full(ffi::gst_query_new_convert(
-                value.get_format().to_glib(),
-                value.get_value(),
-                dest_fmt.to_glib(),
-            ))
-        }
+        Convert(
+            unsafe {
+                from_glib_full(ffi::gst_query_new_convert(
+                    value.get_format().to_glib(),
+                    value.get_value(),
+                    dest_fmt.to_glib(),
+                ))
+            }
+        )
     }
 
-    pub fn new_formats() -> Self {
+    pub fn new_formats() -> Formats {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_formats()) }
+        Formats(
+            unsafe { from_glib_full(ffi::gst_query_new_formats()) }
+        )
     }
 
-    pub fn new_buffering(fmt: ::Format) -> Self {
+    pub fn new_buffering(fmt: ::Format) -> Buffering {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_buffering(fmt.to_glib())) }
+        Buffering(
+            unsafe { from_glib_full(ffi::gst_query_new_buffering(fmt.to_glib())) }
+        )
     }
 
-    pub fn new_custom(structure: ::Structure) -> Self {
+    pub fn new_custom(structure: ::Structure) -> Custom {
         assert_initialized_main_thread!();
-        unsafe {
-            from_glib_full(ffi::gst_query_new_custom(
-                ffi::GST_QUERY_CUSTOM,
-                structure.into_ptr(),
-            ))
-        }
+        Custom(
+            unsafe {
+                from_glib_full(ffi::gst_query_new_custom(
+                    ffi::GST_QUERY_CUSTOM,
+                    structure.into_ptr(),
+                ))
+            }
+        )
     }
 
-    pub fn new_uri() -> Self {
+    pub fn new_uri() -> Uri {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_uri()) }
+        Uri(
+            unsafe { from_glib_full(ffi::gst_query_new_uri()) }
+        )
     }
 
-    pub fn new_scheduling() -> Self {
+    pub fn new_scheduling() -> Scheduling {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_scheduling()) }
+        Scheduling(
+            unsafe { from_glib_full(ffi::gst_query_new_scheduling()) }
+        )
     }
 
-    pub fn new_accept_caps(caps: &::Caps) -> Self {
+    pub fn new_accept_caps(caps: &::Caps) -> AcceptCaps {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_accept_caps(caps.as_mut_ptr())) }
+        AcceptCaps(
+            unsafe { from_glib_full(ffi::gst_query_new_accept_caps(caps.as_mut_ptr())) }
+        )
     }
 
-    pub fn new_caps<'a, P: Into<Option<&'a ::Caps>>>(filter: P) -> Self {
+    pub fn new_caps<'a, P: Into<Option<&'a ::Caps>>>(filter: P) -> Caps {
         assert_initialized_main_thread!();
         let filter = filter.into();
-        unsafe { from_glib_full(ffi::gst_query_new_caps(filter.to_glib_none().0)) }
+        Caps(
+            unsafe { from_glib_full(ffi::gst_query_new_caps(filter.to_glib_none().0)) }
+        )
     }
 
-    pub fn new_drain() -> Self {
+    pub fn new_drain() -> Drain {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_drain()) }
+        Drain(
+            unsafe { from_glib_full(ffi::gst_query_new_drain()) }
+        )
     }
 
-    pub fn new_context(context_type: &str) -> Self {
+    pub fn new_context(context_type: &str) -> Context {
         assert_initialized_main_thread!();
-        unsafe { from_glib_full(ffi::gst_query_new_context(context_type.to_glib_none().0)) }
+        Context(
+            unsafe { from_glib_full(ffi::gst_query_new_context(context_type.to_glib_none().0)) }
+        )
+    }
+
+    pub unsafe fn to_view(ffi_query: *mut ffi::GstQuery) -> QueryView {
+        let (type_, query) = ((*ffi_query).type_, Self::from_glib_none(ffi_query));
+
+        match type_ {
+            ffi::GST_QUERY_POSITION => QueryView::Position(Position(query)),
+            ffi::GST_QUERY_DURATION => QueryView::Duration(Duration(query)),
+            ffi::GST_QUERY_LATENCY => QueryView::Latency(Latency(query)),
+            ffi::GST_QUERY_JITTER => QueryView::Jitter(Jitter(query)),
+            ffi::GST_QUERY_RATE => QueryView::Rate(Rate(query)),
+            ffi::GST_QUERY_SEEKING => QueryView::Seeking(Seeking(query)),
+            ffi::GST_QUERY_SEGMENT => QueryView::Segment(Segment(query)),
+            ffi::GST_QUERY_CONVERT => QueryView::Convert(Convert(query)),
+            ffi::GST_QUERY_FORMATS => QueryView::Formats(Formats(query)),
+            ffi::GST_QUERY_BUFFERING => QueryView::Buffering(Buffering(query)),
+            ffi::GST_QUERY_CUSTOM => QueryView::Custom(Custom(query)),
+            ffi::GST_QUERY_URI => QueryView::Uri(Uri(query)),
+            ffi::GST_QUERY_ALLOCATION => QueryView::Allocation(Allocation(query)),
+            ffi::GST_QUERY_SCHEDULING => QueryView::Scheduling(Scheduling(query)),
+            ffi::GST_QUERY_ACCEPT_CAPS => QueryView::AcceptCaps(AcceptCaps(query)),
+            ffi::GST_QUERY_CAPS => QueryView::Caps(Caps(query)),
+            ffi::GST_QUERY_DRAIN => QueryView::Drain(Drain(query)),
+            ffi::GST_QUERY_CONTEXT => QueryView::Context(Context(query)),
+            _ => QueryView::Other(Other(query)),
+        }
     }
 }
 
@@ -158,36 +214,6 @@ impl QueryRef {
             ((*self.as_ptr()).type_ as u32) & (ffi::GST_QUERY_TYPE_SERIALIZED.bits()) != 0
         }
     }
-
-    pub fn view(&self) -> QueryView<&Self> {
-        let type_ = unsafe { (*self.as_ptr()).type_ };
-
-        match type_ {
-            ffi::GST_QUERY_POSITION => QueryView::Position(Position(self)),
-            ffi::GST_QUERY_DURATION => QueryView::Duration(Duration(self)),
-            ffi::GST_QUERY_LATENCY => QueryView::Latency(Latency(self)),
-            ffi::GST_QUERY_JITTER => QueryView::Jitter(Jitter(self)),
-            ffi::GST_QUERY_RATE => QueryView::Rate(Rate(self)),
-            ffi::GST_QUERY_SEEKING => QueryView::Seeking(Seeking(self)),
-            ffi::GST_QUERY_SEGMENT => QueryView::Segment(Segment(self)),
-            ffi::GST_QUERY_CONVERT => QueryView::Convert(Convert(self)),
-            ffi::GST_QUERY_FORMATS => QueryView::Formats(Formats(self)),
-            ffi::GST_QUERY_BUFFERING => QueryView::Buffering(Buffering(self)),
-            ffi::GST_QUERY_CUSTOM => QueryView::Custom(Custom(self)),
-            ffi::GST_QUERY_URI => QueryView::Uri(Uri(self)),
-            ffi::GST_QUERY_ALLOCATION => QueryView::Allocation(Allocation(self)),
-            ffi::GST_QUERY_SCHEDULING => QueryView::Scheduling(Scheduling(self)),
-            ffi::GST_QUERY_ACCEPT_CAPS => QueryView::AcceptCaps(AcceptCaps(self)),
-            ffi::GST_QUERY_CAPS => QueryView::Caps(Caps(self)),
-            ffi::GST_QUERY_DRAIN => QueryView::Drain(Drain(self)),
-            ffi::GST_QUERY_CONTEXT => QueryView::Context(Context(self)),
-            _ => QueryView::Other(Other(self)),
-        }
-    }
-
-    pub fn view_mut(&mut self) -> QueryView<&mut Self> {
-        unsafe { mem::transmute(self.view()) }
-    }
 }
 
 impl glib::types::StaticType for QueryRef {
@@ -219,73 +245,63 @@ impl ToOwned for QueryRef {
     }
 }
 
-pub enum QueryView<T> {
-    Position(Position<T>),
-    Duration(Duration<T>),
-    Latency(Latency<T>),
-    Jitter(Jitter<T>),
-    Rate(Rate<T>),
-    Seeking(Seeking<T>),
-    Segment(Segment<T>),
-    Convert(Convert<T>),
-    Formats(Formats<T>),
-    Buffering(Buffering<T>),
-    Custom(Custom<T>),
-    Uri(Uri<T>),
-    Allocation(Allocation<T>),
-    Scheduling(Scheduling<T>),
-    AcceptCaps(AcceptCaps<T>),
-    Caps(Caps<T>),
-    Drain(Drain<T>),
-    Context(Context<T>),
-    Other(Other<T>),
+pub enum QueryView {
+    Position(Position),
+    Duration(Duration),
+    Latency(Latency),
+    Jitter(Jitter),
+    Rate(Rate),
+    Seeking(Seeking),
+    Segment(Segment),
+    Convert(Convert),
+    Formats(Formats),
+    Buffering(Buffering),
+    Custom(Custom),
+    Uri(Uri),
+    Allocation(Allocation),
+    Scheduling(Scheduling),
+    AcceptCaps(AcceptCaps),
+    Caps(Caps),
+    Drain(Drain),
+    Context(Context),
+    Other(Other),
     __NonExhaustive,
 }
 
 macro_rules! declare_concrete_query(
-    ($name:ident, $param:ident) => {
-        pub struct $name<$param>($param);
+    ($name:ident) => {
+        pub struct $name(Query);
 
-        impl<'a> $name<&'a QueryRef> {
-            pub fn get_query(&self) -> &QueryRef {
-                self.0
+        impl $name {
+            pub fn view(self) -> QueryView {
+                QueryView::$name(self)
             }
         }
 
-        impl<'a> Deref for $name<&'a QueryRef> {
-            type Target = QueryRef;
+        impl Deref for $name {
+            type Target = Query;
 
             fn deref(&self) -> &Self::Target {
-                self.0
+                &self.0
             }
         }
 
-        impl<'a> $name<&'a mut QueryRef> {
-            pub fn get_mut_query(&mut self) -> &mut QueryRef {
-                self.0
-            }
-        }
-
-        impl<'a> Deref for $name<&'a mut QueryRef> {
-            type Target = $name<&'a QueryRef>;
-
-            fn deref(&self) -> &Self::Target {
-                unsafe {
-                    mem::transmute(self)
-                }
+        impl DerefMut for $name {
+            fn deref_mut(&mut self) -> &mut Query {
+                &mut self.0
             }
         }
     }
 );
 
-declare_concrete_query!(Position, T);
-impl<'a> Position<&'a QueryRef> {
+declare_concrete_query!(Position);
+impl Position {
     pub fn get_result(&self) -> GenericFormattedValue {
         unsafe {
             let mut fmt = mem::uninitialized();
             let mut pos = mem::uninitialized();
 
-            ffi::gst_query_parse_position(self.as_mut_ptr(), &mut fmt, &mut pos);
+            ffi::gst_query_parse_position(self.0.as_mut_ptr(), &mut fmt, &mut pos);
 
             GenericFormattedValue::new(from_glib(fmt), pos)
         }
@@ -295,20 +311,18 @@ impl<'a> Position<&'a QueryRef> {
         unsafe {
             let mut fmt = mem::uninitialized();
 
-            ffi::gst_query_parse_position(self.as_mut_ptr(), &mut fmt, ptr::null_mut());
+            ffi::gst_query_parse_position(self.0.as_mut_ptr(), &mut fmt, ptr::null_mut());
 
             from_glib(fmt)
         }
     }
-}
 
-impl<'a> Position<&'a mut QueryRef> {
     pub fn set<V: Into<GenericFormattedValue>>(&mut self, pos: V) {
         let pos = pos.into();
         assert_eq!(pos.get_format(), self.get_format());
         unsafe {
             ffi::gst_query_set_position(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 pos.get_format().to_glib(),
                 pos.get_value(),
             );
@@ -316,14 +330,14 @@ impl<'a> Position<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Duration, T);
-impl<'a> Duration<&'a QueryRef> {
+declare_concrete_query!(Duration);
+impl Duration {
     pub fn get_result(&self) -> GenericFormattedValue {
         unsafe {
             let mut fmt = mem::uninitialized();
             let mut pos = mem::uninitialized();
 
-            ffi::gst_query_parse_duration(self.as_mut_ptr(), &mut fmt, &mut pos);
+            ffi::gst_query_parse_duration(self.0.as_mut_ptr(), &mut fmt, &mut pos);
 
             GenericFormattedValue::new(from_glib(fmt), pos)
         }
@@ -333,20 +347,18 @@ impl<'a> Duration<&'a QueryRef> {
         unsafe {
             let mut fmt = mem::uninitialized();
 
-            ffi::gst_query_parse_duration(self.as_mut_ptr(), &mut fmt, ptr::null_mut());
+            ffi::gst_query_parse_duration(self.0.as_mut_ptr(), &mut fmt, ptr::null_mut());
 
             from_glib(fmt)
         }
     }
-}
 
-impl<'a> Duration<&'a mut QueryRef> {
     pub fn set<V: Into<GenericFormattedValue>>(&mut self, dur: V) {
         let dur = dur.into();
         assert_eq!(dur.get_format(), self.get_format());
         unsafe {
             ffi::gst_query_set_duration(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 dur.get_format().to_glib(),
                 dur.get_value(),
             );
@@ -354,26 +366,24 @@ impl<'a> Duration<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Latency, T);
-impl<'a> Latency<&'a QueryRef> {
+declare_concrete_query!(Latency);
+impl Latency {
     pub fn get_result(&self) -> (bool, ::ClockTime, ::ClockTime) {
         unsafe {
             let mut live = mem::uninitialized();
             let mut min = mem::uninitialized();
             let mut max = mem::uninitialized();
 
-            ffi::gst_query_parse_latency(self.as_mut_ptr(), &mut live, &mut min, &mut max);
+            ffi::gst_query_parse_latency(self.0.as_mut_ptr(), &mut live, &mut min, &mut max);
 
             (from_glib(live), from_glib(min), from_glib(max))
         }
     }
-}
 
-impl<'a> Latency<&'a mut QueryRef> {
     pub fn set(&mut self, live: bool, min: ::ClockTime, max: ::ClockTime) {
         unsafe {
             ffi::gst_query_set_latency(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 live.to_glib(),
                 min.to_glib(),
                 max.to_glib(),
@@ -382,11 +392,11 @@ impl<'a> Latency<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Jitter, T);
-declare_concrete_query!(Rate, T);
+declare_concrete_query!(Jitter);
+declare_concrete_query!(Rate);
 
-declare_concrete_query!(Seeking, T);
-impl<'a> Seeking<&'a QueryRef> {
+declare_concrete_query!(Seeking);
+impl Seeking {
     pub fn get_result(&self) -> (bool, GenericFormattedValue, GenericFormattedValue) {
         unsafe {
             let mut fmt = mem::uninitialized();
@@ -394,7 +404,7 @@ impl<'a> Seeking<&'a QueryRef> {
             let mut start = mem::uninitialized();
             let mut end = mem::uninitialized();
             ffi::gst_query_parse_seeking(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut fmt,
                 &mut seekable,
                 &mut start,
@@ -413,7 +423,7 @@ impl<'a> Seeking<&'a QueryRef> {
         unsafe {
             let mut fmt = mem::uninitialized();
             ffi::gst_query_parse_seeking(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut fmt,
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -423,9 +433,7 @@ impl<'a> Seeking<&'a QueryRef> {
             from_glib(fmt)
         }
     }
-}
 
-impl<'a> Seeking<&'a mut QueryRef> {
     pub fn set<V: Into<GenericFormattedValue>>(&mut self, seekable: bool, start: V, end: V) {
         let start = start.into();
         let end = end.into();
@@ -435,7 +443,7 @@ impl<'a> Seeking<&'a mut QueryRef> {
 
         unsafe {
             ffi::gst_query_set_seeking(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 start.get_format().to_glib(),
                 seekable.to_glib(),
                 start.get_value(),
@@ -445,8 +453,8 @@ impl<'a> Seeking<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Segment, T);
-impl<'a> Segment<&'a QueryRef> {
+declare_concrete_query!(Segment);
+impl Segment {
     pub fn get_result(&self) -> (f64, GenericFormattedValue, GenericFormattedValue) {
         unsafe {
             let mut rate = mem::uninitialized();
@@ -455,7 +463,7 @@ impl<'a> Segment<&'a QueryRef> {
             let mut stop = mem::uninitialized();
 
             ffi::gst_query_parse_segment(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut rate,
                 &mut fmt,
                 &mut start,
@@ -474,7 +482,7 @@ impl<'a> Segment<&'a QueryRef> {
             let mut fmt = mem::uninitialized();
 
             ffi::gst_query_parse_segment(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 ptr::null_mut(),
                 &mut fmt,
                 ptr::null_mut(),
@@ -483,9 +491,7 @@ impl<'a> Segment<&'a QueryRef> {
             from_glib(fmt)
         }
     }
-}
 
-impl<'a> Segment<&'a mut QueryRef> {
     pub fn set<V: Into<GenericFormattedValue>>(&mut self, rate: f64, start: V, stop: V) {
         let start = start.into();
         let stop = stop.into();
@@ -494,7 +500,7 @@ impl<'a> Segment<&'a mut QueryRef> {
 
         unsafe {
             ffi::gst_query_set_segment(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 rate,
                 start.get_format().to_glib(),
                 start.get_value(),
@@ -504,8 +510,8 @@ impl<'a> Segment<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Convert, T);
-impl<'a> Convert<&'a QueryRef> {
+declare_concrete_query!(Convert);
+impl Convert {
     pub fn get_result(&self) -> (GenericFormattedValue, GenericFormattedValue) {
         unsafe {
             let mut src_fmt = mem::uninitialized();
@@ -514,7 +520,7 @@ impl<'a> Convert<&'a QueryRef> {
             let mut dest = mem::uninitialized();
 
             ffi::gst_query_parse_convert(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut src_fmt,
                 &mut src,
                 &mut dest_fmt,
@@ -534,7 +540,7 @@ impl<'a> Convert<&'a QueryRef> {
             let mut dest_fmt = mem::uninitialized();
 
             ffi::gst_query_parse_convert(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut src_fmt,
                 &mut src,
                 &mut dest_fmt,
@@ -546,16 +552,14 @@ impl<'a> Convert<&'a QueryRef> {
             )
         }
     }
-}
 
-impl<'a> Convert<&'a mut QueryRef> {
     pub fn set<V: Into<GenericFormattedValue>>(&mut self, src: V, dest: V) {
         let src = src.into();
         let dest = dest.into();
 
         unsafe {
             ffi::gst_query_set_convert(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 src.get_format().to_glib(),
                 src.get_value(),
                 dest.get_format().to_glib(),
@@ -565,42 +569,40 @@ impl<'a> Convert<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Formats, T);
-impl<'a> Formats<&'a QueryRef> {
+declare_concrete_query!(Formats);
+impl Formats {
     pub fn get_result(&self) -> Vec<::Format> {
         unsafe {
             let mut n = mem::uninitialized();
-            ffi::gst_query_parse_n_formats(self.as_mut_ptr(), &mut n);
+            ffi::gst_query_parse_n_formats(self.0.as_mut_ptr(), &mut n);
             let mut res = Vec::with_capacity(n as usize);
 
             for i in 0..n {
                 let mut fmt = mem::uninitialized();
-                ffi::gst_query_parse_nth_format(self.as_mut_ptr(), i, &mut fmt);
+                ffi::gst_query_parse_nth_format(self.0.as_mut_ptr(), i, &mut fmt);
                 res.push(from_glib(fmt));
             }
 
             res
         }
     }
-}
 
-impl<'a> Formats<&'a mut QueryRef> {
     pub fn set(&mut self, formats: &[::Format]) {
         unsafe {
             let v: Vec<_> = formats.iter().map(|f| f.to_glib()).collect();
-            ffi::gst_query_set_formatsv(self.as_mut_ptr(), v.len() as i32, v.as_ptr() as *mut _);
+            ffi::gst_query_set_formatsv(self.0.as_mut_ptr(), v.len() as i32, v.as_ptr() as *mut _);
         }
     }
 }
 
-declare_concrete_query!(Buffering, T);
-impl<'a> Buffering<&'a QueryRef> {
+declare_concrete_query!(Buffering);
+impl Buffering {
     pub fn get_format(&self) -> ::Format {
         unsafe {
             let mut fmt = mem::uninitialized();
 
             ffi::gst_query_parse_buffering_range(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut fmt,
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -616,7 +618,7 @@ impl<'a> Buffering<&'a QueryRef> {
             let mut busy = mem::uninitialized();
             let mut percent = mem::uninitialized();
 
-            ffi::gst_query_parse_buffering_percent(self.as_mut_ptr(), &mut busy, &mut percent);
+            ffi::gst_query_parse_buffering_percent(self.0.as_mut_ptr(), &mut busy, &mut percent);
 
             (from_glib(busy), percent)
         }
@@ -630,7 +632,7 @@ impl<'a> Buffering<&'a QueryRef> {
             let mut estimated_total = mem::uninitialized();
 
             ffi::gst_query_parse_buffering_range(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut fmt,
                 &mut start,
                 &mut stop,
@@ -652,7 +654,7 @@ impl<'a> Buffering<&'a QueryRef> {
             let mut buffering_left = mem::uninitialized();
 
             ffi::gst_query_parse_buffering_stats(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut mode,
                 &mut avg_in,
                 &mut avg_out,
@@ -667,7 +669,7 @@ impl<'a> Buffering<&'a QueryRef> {
         unsafe {
             let mut fmt = mem::uninitialized();
             ffi::gst_query_parse_buffering_range(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut fmt,
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -675,13 +677,13 @@ impl<'a> Buffering<&'a QueryRef> {
             );
             let fmt = from_glib(fmt);
 
-            let n = ffi::gst_query_get_n_buffering_ranges(self.as_mut_ptr());
+            let n = ffi::gst_query_get_n_buffering_ranges(self.0.as_mut_ptr());
             let mut res = Vec::with_capacity(n as usize);
             for i in 0..n {
                 let mut start = mem::uninitialized();
                 let mut stop = mem::uninitialized();
                 let s: bool = from_glib(ffi::gst_query_parse_nth_buffering_range(
-                    self.as_mut_ptr(),
+                    self.0.as_mut_ptr(),
                     i,
                     &mut start,
                     &mut stop,
@@ -697,12 +699,10 @@ impl<'a> Buffering<&'a QueryRef> {
             res
         }
     }
-}
 
-impl<'a> Buffering<&'a mut QueryRef> {
     pub fn set_percent(&mut self, busy: bool, percent: i32) {
         unsafe {
-            ffi::gst_query_set_buffering_percent(self.as_mut_ptr(), busy.to_glib(), percent);
+            ffi::gst_query_set_buffering_percent(self.0.as_mut_ptr(), busy.to_glib(), percent);
         }
     }
 
@@ -720,7 +720,7 @@ impl<'a> Buffering<&'a mut QueryRef> {
 
         unsafe {
             ffi::gst_query_set_buffering_range(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 start.get_format().to_glib(),
                 start.get_value(),
                 stop.get_value(),
@@ -739,7 +739,7 @@ impl<'a> Buffering<&'a mut QueryRef> {
         skip_assert_initialized!();
         unsafe {
             ffi::gst_query_set_buffering_stats(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 mode.to_glib(),
                 avg_in,
                 avg_out,
@@ -761,7 +761,7 @@ impl<'a> Buffering<&'a mut QueryRef> {
                 assert_eq!(start.get_format(), fmt);
                 assert_eq!(stop.get_format(), fmt);
                 ffi::gst_query_add_buffering_range(
-                    self.as_mut_ptr(),
+                    self.0.as_mut_ptr(),
                     start.get_value(),
                     stop.get_value(),
                 );
@@ -770,14 +770,14 @@ impl<'a> Buffering<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(Custom, T);
+declare_concrete_query!(Custom);
 
-declare_concrete_query!(Uri, T);
-impl<'a> Uri<&'a QueryRef> {
+declare_concrete_query!(Uri);
+impl Uri {
     pub fn get_uri(&self) -> Option<String> {
         unsafe {
             let mut uri = ptr::null_mut();
-            ffi::gst_query_parse_uri(self.as_mut_ptr(), &mut uri);
+            ffi::gst_query_parse_uri(self.0.as_mut_ptr(), &mut uri);
             from_glib_full(uri)
         }
     }
@@ -785,41 +785,39 @@ impl<'a> Uri<&'a QueryRef> {
     pub fn get_redirection(&self) -> (Option<String>, bool) {
         unsafe {
             let mut uri = ptr::null_mut();
-            ffi::gst_query_parse_uri_redirection(self.as_mut_ptr(), &mut uri);
+            ffi::gst_query_parse_uri_redirection(self.0.as_mut_ptr(), &mut uri);
             let mut permanent = mem::uninitialized();
-            ffi::gst_query_parse_uri_redirection_permanent(self.as_mut_ptr(), &mut permanent);
+            ffi::gst_query_parse_uri_redirection_permanent(self.0.as_mut_ptr(), &mut permanent);
 
             (from_glib_full(uri), from_glib(permanent))
         }
     }
-}
 
-impl<'a> Uri<&'a mut QueryRef> {
     pub fn set_uri<'b, T: Into<&'b str>>(&mut self, uri: T) {
         let uri = uri.into();
         unsafe {
-            ffi::gst_query_set_uri(self.as_mut_ptr(), uri.to_glib_none().0);
+            ffi::gst_query_set_uri(self.0.as_mut_ptr(), uri.to_glib_none().0);
         }
     }
 
     pub fn set_redirection<'b, T: Into<&'b str>>(&mut self, uri: T, permanent: bool) {
         let uri = uri.into();
         unsafe {
-            ffi::gst_query_set_uri_redirection(self.as_mut_ptr(), uri.to_glib_none().0);
-            ffi::gst_query_set_uri_redirection_permanent(self.as_mut_ptr(), permanent.to_glib());
+            ffi::gst_query_set_uri_redirection(self.0.as_mut_ptr(), uri.to_glib_none().0);
+            ffi::gst_query_set_uri_redirection_permanent(self.0.as_mut_ptr(), permanent.to_glib());
         }
     }
 }
 
 // TODO
-declare_concrete_query!(Allocation, T);
+declare_concrete_query!(Allocation);
 
-declare_concrete_query!(Scheduling, T);
-impl<'a> Scheduling<&'a QueryRef> {
+declare_concrete_query!(Scheduling);
+impl Scheduling {
     pub fn has_scheduling_mode(&self, mode: ::PadMode) -> bool {
         unsafe {
             from_glib(ffi::gst_query_has_scheduling_mode(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 mode.to_glib(),
             ))
         }
@@ -833,7 +831,7 @@ impl<'a> Scheduling<&'a QueryRef> {
         skip_assert_initialized!();
         unsafe {
             from_glib(ffi::gst_query_has_scheduling_mode_with_flags(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 mode.to_glib(),
                 flags.to_glib(),
             ))
@@ -842,11 +840,11 @@ impl<'a> Scheduling<&'a QueryRef> {
 
     pub fn get_scheduling_modes(&self) -> Vec<::PadMode> {
         unsafe {
-            let n = ffi::gst_query_get_n_scheduling_modes(self.as_mut_ptr());
+            let n = ffi::gst_query_get_n_scheduling_modes(self.0.as_mut_ptr());
             let mut res = Vec::with_capacity(n as usize);
             for i in 0..n {
                 res.push(from_glib(ffi::gst_query_parse_nth_scheduling_mode(
-                    self.as_mut_ptr(),
+                    self.0.as_mut_ptr(),
                     i,
                 )));
             }
@@ -863,7 +861,7 @@ impl<'a> Scheduling<&'a QueryRef> {
             let mut align = mem::uninitialized();
 
             ffi::gst_query_parse_scheduling(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 &mut flags,
                 &mut minsize,
                 &mut maxsize,
@@ -873,13 +871,11 @@ impl<'a> Scheduling<&'a QueryRef> {
             (from_glib(flags), minsize, maxsize, align)
         }
     }
-}
 
-impl<'a> Scheduling<&'a mut QueryRef> {
     pub fn add_scheduling_modes(&mut self, modes: &[::PadMode]) {
         unsafe {
             for mode in modes {
-                ffi::gst_query_add_scheduling_mode(self.as_mut_ptr(), mode.to_glib());
+                ffi::gst_query_add_scheduling_mode(self.0.as_mut_ptr(), mode.to_glib());
             }
         }
     }
@@ -887,7 +883,7 @@ impl<'a> Scheduling<&'a mut QueryRef> {
     pub fn set(&mut self, flags: ::SchedulingFlags, minsize: i32, maxsize: i32, align: i32) {
         unsafe {
             ffi::gst_query_set_scheduling(
-                self.as_mut_ptr(),
+                self.0.as_mut_ptr(),
                 flags.to_glib(),
                 minsize,
                 maxsize,
@@ -897,12 +893,12 @@ impl<'a> Scheduling<&'a mut QueryRef> {
     }
 }
 
-declare_concrete_query!(AcceptCaps, T);
-impl<'a> AcceptCaps<&'a QueryRef> {
+declare_concrete_query!(AcceptCaps);
+impl AcceptCaps {
     pub fn get_caps(&self) -> &::CapsRef {
         unsafe {
             let mut caps = ptr::null_mut();
-            ffi::gst_query_parse_accept_caps(self.as_mut_ptr(), &mut caps);
+            ffi::gst_query_parse_accept_caps(self.0.as_mut_ptr(), &mut caps);
             ::CapsRef::from_ptr(caps)
         }
     }
@@ -910,26 +906,24 @@ impl<'a> AcceptCaps<&'a QueryRef> {
     pub fn get_result(&self) -> bool {
         unsafe {
             let mut accepted = mem::uninitialized();
-            ffi::gst_query_parse_accept_caps_result(self.as_mut_ptr(), &mut accepted);
+            ffi::gst_query_parse_accept_caps_result(self.0.as_mut_ptr(), &mut accepted);
             from_glib(accepted)
         }
     }
-}
 
-impl<'a> AcceptCaps<&'a mut QueryRef> {
     pub fn set_result(&mut self, accepted: bool) {
         unsafe {
-            ffi::gst_query_set_accept_caps_result(self.as_mut_ptr(), accepted.to_glib());
+            ffi::gst_query_set_accept_caps_result(self.0.as_mut_ptr(), accepted.to_glib());
         }
     }
 }
 
-declare_concrete_query!(Caps, T);
-impl<'a> Caps<&'a QueryRef> {
+declare_concrete_query!(Caps);
+impl Caps {
     pub fn get_filter(&self) -> Option<&::CapsRef> {
         unsafe {
             let mut caps = ptr::null_mut();
-            ffi::gst_query_parse_caps(self.as_mut_ptr(), &mut caps);
+            ffi::gst_query_parse_caps(self.0.as_mut_ptr(), &mut caps);
             if caps.is_null() {
                 None
             } else {
@@ -941,7 +935,7 @@ impl<'a> Caps<&'a QueryRef> {
     pub fn get_result(&self) -> Option<&::CapsRef> {
         unsafe {
             let mut caps = ptr::null_mut();
-            ffi::gst_query_parse_caps_result(self.as_mut_ptr(), &mut caps);
+            ffi::gst_query_parse_caps_result(self.0.as_mut_ptr(), &mut caps);
             if caps.is_null() {
                 None
             } else {
@@ -949,24 +943,22 @@ impl<'a> Caps<&'a QueryRef> {
             }
         }
     }
-}
 
-impl<'a> Caps<&'a mut QueryRef> {
     pub fn set_result(&mut self, caps: &::Caps) {
         unsafe {
-            ffi::gst_query_set_caps_result(self.as_mut_ptr(), caps.as_mut_ptr());
+            ffi::gst_query_set_caps_result(self.0.as_mut_ptr(), caps.as_mut_ptr());
         }
     }
 }
 
-declare_concrete_query!(Drain, T);
+declare_concrete_query!(Drain);
 
-declare_concrete_query!(Context, T);
-impl<'a> Context<&'a QueryRef> {
+declare_concrete_query!(Context);
+impl Context {
     pub fn get_context(&self) -> Option<&::ContextRef> {
         unsafe {
             let mut context = ptr::null_mut();
-            ffi::gst_query_parse_context(self.as_mut_ptr(), &mut context);
+            ffi::gst_query_parse_context(self.0.as_mut_ptr(), &mut context);
             if context.is_null() {
                 None
             } else {
@@ -978,21 +970,19 @@ impl<'a> Context<&'a QueryRef> {
     pub fn get_context_type(&self) -> &str {
         unsafe {
             let mut context_type = ptr::null();
-            ffi::gst_query_parse_context_type(self.as_mut_ptr(), &mut context_type);
+            ffi::gst_query_parse_context_type(self.0.as_mut_ptr(), &mut context_type);
             CStr::from_ptr(context_type).to_str().unwrap()
         }
     }
-}
 
-impl<'a> Context<&'a mut QueryRef> {
     pub fn set_context(&mut self, context: &::Context) {
         unsafe {
-            ffi::gst_query_set_context(self.as_mut_ptr(), context.as_mut_ptr());
+            ffi::gst_query_set_context(self.0.as_mut_ptr(), context.as_mut_ptr());
         }
     }
 }
 
-declare_concrete_query!(Other, T);
+declare_concrete_query!(Other);
 
 #[cfg(test)]
 mod tests {
@@ -1004,26 +994,19 @@ mod tests {
 
         let mut q = Query::new_position(::Format::Time);
 
-        match q.view() {
-            QueryView::Position(ref p) => {
-                let fmt = p.get_format();
-                assert_eq!(fmt, ::Format::Time);
-                assert!(!p.is_serialized());
-            }
-            _ => (),
-        }
+        let fmt = q.get_format();
+        assert_eq!(fmt, ::Format::Time);
+        assert!(!q.is_serialized());
 
-        match q.get_mut().unwrap().view_mut() {
-            QueryView::Position(ref mut p) => {
-                let pos = p.get_result();
-                assert_eq!(pos.try_into_time(), Ok(::CLOCK_TIME_NONE));
-                p.set(2 * ::SECOND);
-            }
-            _ => (),
-        }
+        let pos = q.get_result();
+        assert_eq!(pos.try_into_time(), Ok(::CLOCK_TIME_NONE));
+        q.set(2 * ::SECOND);
+
+        let pos = q.get_result();
+        assert_eq!(pos.try_into_time(), Ok(2 * ::SECOND));
 
         match q.view() {
-            QueryView::Position(ref p) => {
+            QueryView::Position(p) => {
                 let pos = p.get_result();
                 assert_eq!(pos.try_into_time(), Ok(2 * ::SECOND));
             }

--- a/gstreamer/src/query.rs
+++ b/gstreamer/src/query.rs
@@ -150,30 +150,112 @@ impl GstRc<QueryRef> {
             unsafe { from_glib_full(ffi::gst_query_new_context(context_type.to_glib_none().0)) }
         )
     }
+}
 
-    pub unsafe fn to_view(ffi_query: *mut ffi::GstQuery) -> QueryView {
-        let (type_, query) = ((*ffi_query).type_, Self::from_glib_none(ffi_query));
+impl From<QueryView> for Query {
+    fn from(view: QueryView) -> Self {
+        match view {
+            QueryView::Position(position) => position.into(),
+            QueryView::Duration(duration) => duration.into(),
+            QueryView::Latency(latency) => latency.into(),
+            QueryView::Jitter(jitter) => jitter.into(),
+            QueryView::Rate(rate) => rate.into(),
+            QueryView::Seeking(seeking) => seeking.into(),
+            QueryView::Segment(segment) => segment.into(),
+            QueryView::Convert(convert) => convert.into(),
+            QueryView::Formats(formats) => formats.into(),
+            QueryView::Buffering(buffering) => buffering.into(),
+            QueryView::Custom(custom) => custom.into(),
+            QueryView::Uri(uri) => uri.into(),
+            QueryView::Allocation(allocation) => allocation.into(),
+            QueryView::Scheduling(scheduling) => scheduling.into(),
+            QueryView::AcceptCaps(accept_caps) => accept_caps.into(),
+            QueryView::Caps(caps) => caps.into(),
+            QueryView::Drain(drain) => drain.into(),
+            QueryView::Context(context) => context.into(),
+            QueryView::Other(other) => other.into(),
+            _ => unimplemented!("Converting QueryView into Query for unknown query type"),
+        }
+    }
+}
 
-        match type_ {
-            ffi::GST_QUERY_POSITION => QueryView::Position(Position(query)),
-            ffi::GST_QUERY_DURATION => QueryView::Duration(Duration(query)),
-            ffi::GST_QUERY_LATENCY => QueryView::Latency(Latency(query)),
-            ffi::GST_QUERY_JITTER => QueryView::Jitter(Jitter(query)),
-            ffi::GST_QUERY_RATE => QueryView::Rate(Rate(query)),
-            ffi::GST_QUERY_SEEKING => QueryView::Seeking(Seeking(query)),
-            ffi::GST_QUERY_SEGMENT => QueryView::Segment(Segment(query)),
-            ffi::GST_QUERY_CONVERT => QueryView::Convert(Convert(query)),
-            ffi::GST_QUERY_FORMATS => QueryView::Formats(Formats(query)),
-            ffi::GST_QUERY_BUFFERING => QueryView::Buffering(Buffering(query)),
-            ffi::GST_QUERY_CUSTOM => QueryView::Custom(Custom(query)),
-            ffi::GST_QUERY_URI => QueryView::Uri(Uri(query)),
-            ffi::GST_QUERY_ALLOCATION => QueryView::Allocation(Allocation(query)),
-            ffi::GST_QUERY_SCHEDULING => QueryView::Scheduling(Scheduling(query)),
-            ffi::GST_QUERY_ACCEPT_CAPS => QueryView::AcceptCaps(AcceptCaps(query)),
-            ffi::GST_QUERY_CAPS => QueryView::Caps(Caps(query)),
-            ffi::GST_QUERY_DRAIN => QueryView::Drain(Drain(query)),
-            ffi::GST_QUERY_CONTEXT => QueryView::Context(Context(query)),
-            _ => QueryView::Other(Other(query)),
+impl<'a> From<&'a QueryView> for &'a Query {
+    fn from(view: &'a QueryView) -> Self {
+        match *view {
+            QueryView::Position(ref position) => position.into(),
+            QueryView::Duration(ref duration) => duration.into(),
+            QueryView::Latency(ref latency) => latency.into(),
+            QueryView::Jitter(ref jitter) => jitter.into(),
+            QueryView::Rate(ref rate) => rate.into(),
+            QueryView::Seeking(ref seeking) => seeking.into(),
+            QueryView::Segment(ref segment) => segment.into(),
+            QueryView::Convert(ref convert) => convert.into(),
+            QueryView::Formats(ref formats) => formats.into(),
+            QueryView::Buffering(ref buffering) => buffering.into(),
+            QueryView::Custom(ref custom) => custom.into(),
+            QueryView::Uri(ref uri) => uri.into(),
+            QueryView::Allocation(ref allocation) => allocation.into(),
+            QueryView::Scheduling(ref scheduling) => scheduling.into(),
+            QueryView::AcceptCaps(ref accept_caps) => accept_caps.into(),
+            QueryView::Caps(ref caps) => caps.into(),
+            QueryView::Drain(ref drain) => drain.into(),
+            QueryView::Context(ref context) => context.into(),
+            QueryView::Other(ref other) => other.into(),
+            _ => unimplemented!("Converting QueryView into Query for unknown query type"),
+        }
+    }
+}
+
+impl<'a> From<&'a mut QueryView> for &'a Query {
+    fn from(view: &'a mut QueryView) -> Self {
+        match *view {
+            QueryView::Position(ref position) => position.into(),
+            QueryView::Duration(ref duration) => duration.into(),
+            QueryView::Latency(ref latency) => latency.into(),
+            QueryView::Jitter(ref jitter) => jitter.into(),
+            QueryView::Rate(ref rate) => rate.into(),
+            QueryView::Seeking(ref seeking) => seeking.into(),
+            QueryView::Segment(ref segment) => segment.into(),
+            QueryView::Convert(ref convert) => convert.into(),
+            QueryView::Formats(ref formats) => formats.into(),
+            QueryView::Buffering(ref buffering) => buffering.into(),
+            QueryView::Custom(ref custom) => custom.into(),
+            QueryView::Uri(ref uri) => uri.into(),
+            QueryView::Allocation(ref allocation) => allocation.into(),
+            QueryView::Scheduling(ref scheduling) => scheduling.into(),
+            QueryView::AcceptCaps(ref accept_caps) => accept_caps.into(),
+            QueryView::Caps(ref caps) => caps.into(),
+            QueryView::Drain(ref drain) => drain.into(),
+            QueryView::Context(ref context) => context.into(),
+            QueryView::Other(ref other) => other.into(),
+            _ => unimplemented!("Converting QueryView into Query for unknown query type"),
+        }
+    }
+}
+
+impl<'a> From<&'a mut QueryView> for &'a mut Query {
+    fn from(view: &'a mut QueryView) -> Self {
+        match *view {
+            QueryView::Position(ref mut position) => position.into(),
+            QueryView::Duration(ref mut duration) => duration.into(),
+            QueryView::Latency(ref mut latency) => latency.into(),
+            QueryView::Jitter(ref mut jitter) => jitter.into(),
+            QueryView::Rate(ref mut rate) => rate.into(),
+            QueryView::Seeking(ref mut seeking) => seeking.into(),
+            QueryView::Segment(ref mut segment) => segment.into(),
+            QueryView::Convert(ref mut convert) => convert.into(),
+            QueryView::Formats(ref mut formats) => formats.into(),
+            QueryView::Buffering(ref mut buffering) => buffering.into(),
+            QueryView::Custom(ref mut custom) => custom.into(),
+            QueryView::Uri(ref mut uri) => uri.into(),
+            QueryView::Allocation(ref mut allocation) => allocation.into(),
+            QueryView::Scheduling(ref mut scheduling) => scheduling.into(),
+            QueryView::AcceptCaps(ref mut accept_caps) => accept_caps.into(),
+            QueryView::Caps(ref mut caps) => caps.into(),
+            QueryView::Drain(ref mut drain) => drain.into(),
+            QueryView::Context(ref mut context) => context.into(),
+            QueryView::Other(ref mut other) => other.into(),
+            _ => unimplemented!("Converting QueryView into Query for unknown query type"),
         }
     }
 }
@@ -245,6 +327,7 @@ impl ToOwned for QueryRef {
     }
 }
 
+#[derive(Debug)]
 pub enum QueryView {
     Position(Position),
     Duration(Duration),
@@ -268,13 +351,72 @@ pub enum QueryView {
     __NonExhaustive,
 }
 
+impl From<Query> for QueryView {
+    fn from(query: Query) -> Self {
+        let type_ = (query.0).type_;
+
+        match type_ {
+            ffi::GST_QUERY_POSITION => QueryView::Position(Position(query)),
+            ffi::GST_QUERY_DURATION => QueryView::Duration(Duration(query)),
+            ffi::GST_QUERY_LATENCY => QueryView::Latency(Latency(query)),
+            ffi::GST_QUERY_JITTER => QueryView::Jitter(Jitter(query)),
+            ffi::GST_QUERY_RATE => QueryView::Rate(Rate(query)),
+            ffi::GST_QUERY_SEEKING => QueryView::Seeking(Seeking(query)),
+            ffi::GST_QUERY_SEGMENT => QueryView::Segment(Segment(query)),
+            ffi::GST_QUERY_CONVERT => QueryView::Convert(Convert(query)),
+            ffi::GST_QUERY_FORMATS => QueryView::Formats(Formats(query)),
+            ffi::GST_QUERY_BUFFERING => QueryView::Buffering(Buffering(query)),
+            ffi::GST_QUERY_CUSTOM => QueryView::Custom(Custom(query)),
+            ffi::GST_QUERY_URI => QueryView::Uri(Uri(query)),
+            ffi::GST_QUERY_ALLOCATION => QueryView::Allocation(Allocation(query)),
+            ffi::GST_QUERY_SCHEDULING => QueryView::Scheduling(Scheduling(query)),
+            ffi::GST_QUERY_ACCEPT_CAPS => QueryView::AcceptCaps(AcceptCaps(query)),
+            ffi::GST_QUERY_CAPS => QueryView::Caps(Caps(query)),
+            ffi::GST_QUERY_DRAIN => QueryView::Drain(Drain(query)),
+            ffi::GST_QUERY_CONTEXT => QueryView::Context(Context(query)),
+            _ => QueryView::Other(Other(query)),
+        }
+    }
+}
+
 macro_rules! declare_concrete_query(
     ($name:ident) => {
+        #[derive(Debug)]
         pub struct $name(Query);
 
         impl $name {
-            pub fn view(self) -> QueryView {
-                QueryView::$name(self)
+            pub unsafe fn into_ptr(self) -> *mut ffi::GstQuery {
+                self.0.into_ptr()
+            }
+        }
+
+        impl From<$name> for QueryView {
+            fn from(concrete: $name) -> QueryView {
+                QueryView::$name($name(concrete.0))
+            }
+        }
+
+        impl From<$name> for Query {
+            fn from(concrete: $name) -> Query {
+                concrete.0
+            }
+        }
+
+        impl<'a> From<&'a $name> for &'a Query {
+            fn from(concrete: &'a $name) -> &'a Query {
+                &concrete.0
+            }
+        }
+
+        impl<'a> From<&'a mut $name> for &'a Query {
+            fn from(concrete: &'a mut $name) -> &'a Query {
+                &concrete.0
+            }
+        }
+
+        impl<'a> From<&'a mut $name> for &'a mut Query {
+            fn from(concrete: &'a mut $name) -> &'a mut Query {
+                &mut concrete.0
             }
         }
 
@@ -992,25 +1134,115 @@ mod tests {
     fn test_writability() {
         ::init().unwrap();
 
-        let mut q = Query::new_position(::Format::Time);
+        let mut p = Query::new_position(::Format::Time);
 
-        let fmt = q.get_format();
+        let fmt = p.get_format();
         assert_eq!(fmt, ::Format::Time);
-        assert!(!q.is_serialized());
 
-        let pos = q.get_result();
+        // deref
+        assert!(!p.is_serialized());
+
+        let pos = p.get_result();
         assert_eq!(pos.try_into_time(), Ok(::CLOCK_TIME_NONE));
-        q.set(2 * ::SECOND);
+        p.set(2 * ::SECOND);
 
-        let pos = q.get_result();
+        let pos = p.get_result();
         assert_eq!(pos.try_into_time(), Ok(2 * ::SECOND));
+    }
 
-        match q.view() {
-            QueryView::Position(p) => {
-                let pos = p.get_result();
-                assert_eq!(pos.try_into_time(), Ok(2 * ::SECOND));
-            }
-            _ => (),
+    #[test]
+    fn test_generic_ref() {
+        fn check_ref(q: &Query) {
+            assert!(q.is_writable());
+            unsafe { assert!(!q.as_mut_ptr().is_null()); }
         }
+
+        let p = Query::new_position(::Format::Time);
+        check_ref(&p);
+
+        let fmt = p.get_format();
+        assert_eq!(fmt, ::Format::Time);
+    }
+
+    #[test]
+    fn test_view_from_generic() {
+        fn check_generic(q: Query) {
+            match q.into() {
+                QueryView::Position(mut p) => {
+                    let pos = p.get_result();
+                    assert_eq!(pos.try_into_time(), Ok(2 * ::SECOND));
+                    p.set(3 * ::SECOND);
+                    let pos = p.get_result();
+                    assert_eq!(pos.try_into_time(), Ok(3 * ::SECOND));
+               }
+                _ => panic!("Wrong concrete Query in QueryView"),
+            }
+        }
+
+        let mut p = Query::new_position(::Format::Time);
+        p.set(2 * ::SECOND);
+
+        check_generic(p.into());
+    }
+
+    #[test]
+    fn test_view_from_concrete() {
+        fn check_view(view: &mut QueryView) {
+            use glib::ToSendValue;
+            match *view {
+                QueryView::Position(ref mut p) => {
+                    let pos = p.get_result();
+                    assert_eq!(pos.try_into_time(), Ok(2 * ::SECOND));
+                    p.set(3 * ::SECOND);
+               }
+                _ => panic!("Wrong concrete Query in QueryView"),
+            }
+
+            {
+                // ref mut QueryView to generic Query as ref
+                let query: &Query = view.into();
+                assert_eq!((query.0).type_, ffi::GST_QUERY_POSITION);
+            }
+
+            {
+                // ref mut QueryView to generic Query as ref mut
+                let query: &mut Query = view.into();
+                {
+                    let structure = query.get_mut().unwrap().get_mut_structure();
+                    structure.set_value("test", true.to_send_value());
+                }
+                unsafe { assert!(!query.as_mut_ptr().is_null()); }
+            }
+        }
+
+        // Concrete Position
+        let mut p = Query::new_position(::Format::Time);
+        p.set(2 * ::SECOND);
+
+        // Postion to QueryView
+        let mut view: QueryView = p.into();
+        check_view(&mut view);
+
+        match view {
+            QueryView::Position(ref p) => {
+                let pos = p.get_result();
+                assert_eq!(pos.try_into_time(), Ok(3 * ::SECOND));
+           }
+            _ => panic!("Wrong concrete Query in QueryView"),
+        }
+
+        // QueryView to generic Query
+        let query: &Query = &view.into();
+        assert_eq!((query.0).type_, ffi::GST_QUERY_POSITION);
+
+        // structure was updated in function check_view
+        let structure = query.get_structure().unwrap();
+        assert!(structure.has_field("test"));
+    }
+
+    #[test]
+    fn test_concrete_to_ffi() {
+        let p = Query::new_position(::Format::Time);
+        unsafe { assert!(!p.into_ptr().is_null()); }
     }
 }

--- a/gstreamer/src/query.rs
+++ b/gstreamer/src/query.rs
@@ -272,6 +272,14 @@ impl fmt::Debug for QueryRef {
     }
 }
 
+impl Drop for QueryRef {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::gst_mini_object_unref(self.as_mut_ptr() as *mut ffi::GstMiniObject);
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum QueryView {
     Position(Position),

--- a/tutorials/src/bin/basic-tutorial-4.rs
+++ b/tutorials/src/bin/basic-tutorial-4.rs
@@ -128,7 +128,7 @@ fn handle_message(custom_data: &mut CustomData, msg: &gst::GstRc<gst::MessageRef
 
             custom_data.playing = new_state == gst::State::Playing;
             if custom_data.playing {
-                let mut seeking = gst::Query::new_seeking(gst::Format::Time);
+                let mut seeking = gst::QueryRef::new_seeking(gst::Format::Time);
                 if custom_data.playbin.query(&mut seeking) {
                     let (seekable, start, end) = seeking.get_result();
                     custom_data.seek_enabled = seekable;

--- a/tutorials/src/bin/basic-tutorial-4.rs
+++ b/tutorials/src/bin/basic-tutorial-4.rs
@@ -128,19 +128,14 @@ fn handle_message(custom_data: &mut CustomData, msg: &gst::GstRc<gst::MessageRef
 
             custom_data.playing = new_state == gst::State::Playing;
             if custom_data.playing {
-                let mut query = gst::Query::new_seeking(gst::Format::Time);
-                if custom_data.playbin.query(query.get_mut().unwrap()) {
-                    match query.view() {
-                        gst::QueryView::Seeking(seek) => {
-                            let (seekable, start, end) = seek.get_result();
-                            custom_data.seek_enabled = seekable;
-                            if seekable {
-                                println!("Seeking is ENABLED from {:?} to {:?}", start, end)
-                            } else {
-                                println!("Seeking is DISABLED for this stream.")
-                            }
-                        }
-                        _ => unreachable!(),
+                let mut seeking = gst::Query::new_seeking(gst::Format::Time);
+                if custom_data.playbin.query(&mut seeking) {
+                    let (seekable, start, end) = seeking.get_result();
+                    custom_data.seek_enabled = seekable;
+                    if seekable {
+                        println!("Seeking is ENABLED from {:?} to {:?}", start, end)
+                    } else {
+                        println!("Seeking is DISABLED for this stream.")
                     }
                 } else {
                     eprintln!("Seeking query failed.")

--- a/tutorials/src/bin/basic-tutorial-4.rs
+++ b/tutorials/src/bin/basic-tutorial-4.rs
@@ -128,7 +128,7 @@ fn handle_message(custom_data: &mut CustomData, msg: &gst::GstRc<gst::MessageRef
 
             custom_data.playing = new_state == gst::State::Playing;
             if custom_data.playing {
-                let mut seeking = gst::QueryRef::new_seeking(gst::Format::Time);
+                let mut seeking = gst::Query::new_seeking(gst::Format::Time);
                 if custom_data.playbin.query(&mut seeking) {
                     let (seekable, start, end) = seeking.get_result();
                     custom_data.seek_enabled = seekable;


### PR DESCRIPTION
While trying to solve the deref/deref_mut issue on concrete types, I came up with the approach in this commit. The idea is to allow working with concrete implementations directly. Except for pad probes, views are no longer necessary. See unit test and examples.

In pad probes, the user gets the query view directly. E.g.:
``` rust
    src_pad.add_probe(PadProbeType::QUERY_UPSTREAM, |_, probe_info| {
        if let Some(PadProbeData::Query(ref mut query_view)) = probe_info.data {
            match query_view {
                &mut QueryView::Duration(ref mut duration) => {
                    duration.set(2 * SECOND);
                },
                _ => (),
            }
        }
        PadProbeReturn::Ok
    });
```

Note: calling `view` consumes the query, but I don't think this is an issue as the idea is to work on concrete implementations and the user should no longer need to call `view` anyway.

If I'm not mistaken, this could apply to `Event`s & `Message`s too.