### PR TITLE
Bus: fix feature gate unix / windows

### DIFF
--- a/gstreamer/src/bus.rs
+++ b/gstreamer/src/bus.rs
@@ -18,10 +18,10 @@ use std::ptr;
 #[cfg(any(feature = "v1_14", feature = "dox"))]
 use std::mem;
 
-#[cfg(any(all(unix, feature = "v1_14"), feature = "dox"))]
+#[cfg(all(unix, any(feature = "v1_14", feature = "dox")))]
 use std::os::unix;
 
-#[cfg(any(all(not(unix), feature = "v1_14"), feature = "dox"))]
+#[cfg(all(not(unix), any(feature = "v1_14", feature = "dox")))]
 use std::os::windows;
 
 use Bus;
@@ -147,7 +147,7 @@ impl Bus {
         unsafe { ffi::gst_bus_set_sync_handler(self.to_glib_none().0, None, ptr::null_mut(), None) }
     }
 
-    #[cfg(any(all(unix, feature = "v1_14"), feature = "dox"))]
+    #[cfg(all(unix, any(feature = "v1_14", feature = "dox")))]
     pub fn get_pollfd(&self) -> unix::io::RawFd {
         unsafe {
             let mut pollfd: glib_ffi::GPollFD = mem::zeroed();
@@ -157,7 +157,7 @@ impl Bus {
         }
     }
 
-    #[cfg(any(all(not(unix), feature = "v1_14"), feature = "dox"))]
+    #[cfg(all(not(unix), any(feature = "v1_14", feature = "dox")))]
     pub fn get_pollfd(&self) -> windows::io::RawHandle {
         unsafe {
             let mut pollfd: glib_ffi::GPollFD = mem::zeroed();


### PR DESCRIPTION
OS dependent conditions were tied to `dox` which would bypass them when using feature `dox` or `--all-features`