### PR TITLE
 Bus::get_pollfd generate doc for both unix & windows 

### DIFF
--- a/gstreamer/Cargo.toml
+++ b/gstreamer/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 
 [dependencies]
 bitflags = "1.0"
+cfg-if = "0.1"
 libc = "0.2"
 glib-sys = { git = "https://github.com/gtk-rs/sys" }
 gobject-sys = { git = "https://github.com/gtk-rs/sys" }

--- a/gstreamer/src/bus.rs
+++ b/gstreamer/src/bus.rs
@@ -15,14 +15,6 @@ use glib::source::{CallbackGuard, Continue, Priority, SourceId};
 use glib_ffi;
 use glib_ffi::{gboolean, gpointer};
 use std::ptr;
-#[cfg(any(feature = "v1_14", feature = "dox"))]
-use std::mem;
-
-#[cfg(any(all(unix, feature = "v1_14"), feature = "dox"))]
-use std::os::unix;
-
-#[cfg(any(all(not(unix), feature = "v1_14"), feature = "dox"))]
-use std::os::windows;
 
 use Bus;
 use BusSyncReply;
@@ -145,26 +137,6 @@ impl Bus {
 
     pub fn unset_sync_handler(&self) {
         unsafe { ffi::gst_bus_set_sync_handler(self.to_glib_none().0, None, ptr::null_mut(), None) }
-    }
-
-    #[cfg(any(all(unix, feature = "v1_14"), feature = "dox"))]
-    pub fn get_pollfd(&self) -> unix::io::RawFd {
-        unsafe {
-            let mut pollfd: glib_ffi::GPollFD = mem::zeroed();
-            ffi::gst_bus_get_pollfd(self.to_glib_none().0, &mut pollfd);
-
-            pollfd.fd
-        }
-    }
-
-    #[cfg(any(all(not(unix), feature = "v1_14"), feature = "dox"))]
-    pub fn get_pollfd(&self) -> windows::io::RawHandle {
-        unsafe {
-            let mut pollfd: glib_ffi::GPollFD = mem::zeroed();
-            ffi::gst_bus_get_pollfd(self.to_glib_none().0, &mut pollfd);
-
-            pollfd.fd as *mut _
-        }
     }
 }
 

--- a/gstreamer/src/bus_unix.rs
+++ b/gstreamer/src/bus_unix.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2016-2018 Sebastian Dröge <sebastian@centricular.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+cfg_if! {
+    if #[cfg(unix)] {
+        use ffi;
+        use glib_ffi;
+        use glib::translate::ToGlibPtr;
+
+        use std::mem;
+        use std::os::unix;
+    } else if #[cfg(feature = "dox")] {
+        // Declare a fake RawFd for doc generation on windows
+        pub mod unix {
+            pub mod io {
+                pub struct RawFd{}
+            }
+        }
+    }
+}
+
+use super::Bus;
+
+pub trait UnixBusExtManual {
+    fn get_pollfd(&self) -> unix::io::RawFd;
+}
+
+impl UnixBusExtManual for Bus {
+    /// This is supported on **Unix** only.
+    fn get_pollfd(&self) -> unix::io::RawFd {
+        #[cfg(unix)]
+        unsafe {
+            let mut pollfd: glib_ffi::GPollFD = mem::zeroed();
+            ffi::gst_bus_get_pollfd(self.to_glib_none().0, &mut pollfd);
+
+            pollfd.fd
+        }
+
+        #[cfg(all(not(unix), feature = "dox"))]
+        unix::io::RawFd {}
+    }
+}

--- a/gstreamer/src/bus_windows.rs
+++ b/gstreamer/src/bus_windows.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2016-2018 Sebastian Dröge <sebastian@centricular.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+cfg_if! {
+    if #[cfg(windows)] {
+        use ffi;
+        use glib_ffi;
+        use glib::translate::ToGlibPtr;
+
+        use std::mem;
+        use std::os::windows;
+    } else if #[cfg(feature = "dox")] {
+        // Declare a fake RawHandle for doc generation on unix
+        pub mod windows {
+            pub mod io {
+                pub struct RawHandle{}
+            }
+        }
+    }
+}
+
+use super::Bus;
+
+pub trait WindowsBusExtManual {
+    fn get_pollfd(&self) -> windows::io::RawHandle;
+}
+
+impl WindowsBusExtManual for Bus {
+    /// This is supported on **Windows** only.
+    fn get_pollfd(&self) -> windows::io::RawHandle {
+        #[cfg(windows)]
+        unsafe {
+            let mut pollfd: glib_ffi::GPollFD = mem::zeroed();
+            ffi::gst_bus_get_pollfd(self.to_glib_none().0, &mut pollfd);
+
+            pollfd.fd as *mut _
+        }
+
+        #[cfg(all(not(windows), feature = "dox"))]
+        windows::io::RawHandle {}
+    }
+}

--- a/gstreamer/src/lib.rs
+++ b/gstreamer/src/lib.rs
@@ -9,6 +9,9 @@
 #![recursion_limit = "256"]
 #[macro_use]
 extern crate bitflags;
+#[cfg(any(feature = "v1_14", feature = "dox"))]
+#[macro_use]
+extern crate cfg_if;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
@@ -102,6 +105,21 @@ pub use promise::*;
 mod element;
 mod bin;
 mod bus;
+
+// OS dependent Bus extensions (also import the other plateform mod for doc)
+#[cfg(any(feature = "v1_14", feature = "dox"))]
+cfg_if! {
+    if #[cfg(unix)] {
+        mod bus_unix;
+        #[cfg(feature = "dox")]
+        mod bus_windows;
+    } else {
+        mod bus_windows;
+        #[cfg(feature = "dox")]
+        mod bus_unix;
+    }
+}
+
 mod pad;
 mod object;
 mod gobject;
@@ -120,6 +138,21 @@ pub use element::{ElementExtManual, ElementMessageType, NotifyWatchId};
 pub use element::{ELEMENT_METADATA_AUTHOR, ELEMENT_METADATA_DESCRIPTION, ELEMENT_METADATA_DOC_URI,
                   ELEMENT_METADATA_ICON_NAME, ELEMENT_METADATA_KLASS, ELEMENT_METADATA_LONGNAME};
 pub use bin::BinExtManual;
+
+// OS dependent Bus extensions (also import the other plateform trait for doc)
+#[cfg(any(feature = "v1_14", feature = "dox"))]
+cfg_if! {
+    if #[cfg(unix)] {
+        pub use bus_unix::UnixBusExtManual;
+        #[cfg(feature = "dox")]
+        pub use bus_windows::WindowsBusExtManual;
+    } else {
+        pub use bus_windows::WindowsBusExtManual;
+        #[cfg(feature = "dox")]
+        pub use bus_unix::UnixBusExtManual;
+    }
+}
+
 pub use pad::{PadExtManual, PadProbeData, PadProbeId, PadProbeInfo};
 pub use gobject::GObjectExtManualGst;
 pub use child_proxy::ChildProxyExtManual;
@@ -205,6 +238,21 @@ pub mod prelude {
 
     pub use element::ElementExtManual;
     pub use bin::BinExtManual;
+
+    // OS dependent Bus extensions (also import the other plateform trait for doc)
+    #[cfg(any(feature = "v1_14", feature = "dox"))]
+    cfg_if! {
+        if #[cfg(unix)] {
+            pub use bus_unix::UnixBusExtManual;
+            #[cfg(feature = "dox")]
+            pub use bus_windows::WindowsBusExtManual;
+        } else {
+            pub use bus_windows::WindowsBusExtManual;
+            #[cfg(feature = "dox")]
+            pub use bus_unix::UnixBusExtManual;
+        }
+    }
+
     pub use pad::PadExtManual;
     pub use object::GstObjectExtManual;
     pub use gobject::GObjectExtManualGst;


### PR DESCRIPTION
There are different implementations and signatures for `get_pollfd` depending
on whether the target platform is unix or windows. When generating the doc,
we need both implementations to appear regardless of the target platform. This
commit is inspired by the way Rust `std` library deals with [`process::Command`
OS dependent variants](https://doc.rust-lang.org/std/process/struct.Command.html#impl-CommandExt).

Documentation can't be accurate though as we can't use the`std::os::windows`
on `unix` and vice versa. As a workaround a fake fd class matching the other
platform is declared.

This could be further enhanced once [`#[doc(cfg(...))]` is stabilized](https://github.com/rust-lang/rust/issues/43781)
by declaring `#[doc(cfg(unix))]` or `#[doc(cfg(windows))]` instead of the hard coded
comments `This is supported on **Windows/Unix** only`. Unfortunately, these
comments disappear when generating with `--all-features` because they are not part
of the documentation in the gir file. Is there a way to prevent them from being removed?