### PR TITLE
Add untyped/dynamic tag getter/adder

### DIFF
--- a/gstreamer/src/tags.rs
+++ b/gstreamer/src/tags.rs
@@ -28,399 +28,128 @@ pub trait Tag<'a> {
 }
 
 macro_rules! impl_tag(
-    ($name:ident, $t:ty, $tag:expr) => {
+    ($name:ident, $t:ty, $rust_tag:ident, $gst_tag:ident) => {
         pub struct $name;
         impl<'a> Tag<'a> for $name {
             type TagType = $t;
             fn tag_name<'b>() -> &'b str {
-                $tag
+                *$rust_tag
             }
+        }
+
+        lazy_static! {
+            static ref $rust_tag: &'static str =
+                unsafe { CStr::from_ptr(ffi::$gst_tag).to_str().unwrap() };
         }
     };
 );
 
-impl_tag!(Title, &'a str, *TAG_TITLE);
-impl_tag!(TitleSortname, &'a str, *TAG_TITLE_SORTNAME);
-impl_tag!(Artist, &'a str, *TAG_ARTIST);
-impl_tag!(ArtistSortname, &'a str, *TAG_ARTIST_SORTNAME);
-impl_tag!(Album, &'a str, *TAG_ALBUM);
-impl_tag!(AlbumSortname, &'a str, *TAG_ALBUM_SORTNAME);
-impl_tag!(AlbumArtist, &'a str, *TAG_ALBUM_ARTIST);
-impl_tag!(AlbumArtistSortname, &'a str, *TAG_ALBUM_ARTIST_SORTNAME);
-impl_tag!(Date, glib::Date, *TAG_DATE);
-impl_tag!(DateTime, ::auto::DateTime, *TAG_DATE_TIME);
-impl_tag!(Genre, &'a str, *TAG_GENRE);
-impl_tag!(Comment, &'a str, *TAG_COMMENT);
-impl_tag!(ExtendedComment, &'a str, *TAG_EXTENDED_COMMENT);
-impl_tag!(TrackNumber, u32, *TAG_TRACK_NUMBER);
-impl_tag!(TrackCount, u32, *TAG_TRACK_COUNT);
-impl_tag!(AlbumVolumeNumber, u32, *TAG_ALBUM_VOLUME_NUMBER);
-impl_tag!(AlbumVolumeCount, u32, *TAG_ALBUM_VOLUME_COUNT);
-impl_tag!(Location, &'a str, *TAG_LOCATION);
-impl_tag!(Homepage, &'a str, *TAG_HOMEPAGE);
-impl_tag!(Description, &'a str, *TAG_DESCRIPTION);
-impl_tag!(Version, &'a str, *TAG_VERSION);
-impl_tag!(ISRC, &'a str, *TAG_ISRC);
-impl_tag!(Organization, &'a str, *TAG_ORGANIZATION);
-impl_tag!(Copyright, &'a str, *TAG_COPYRIGHT);
-impl_tag!(CopyrightUri, &'a str, *TAG_COPYRIGHT_URI);
-impl_tag!(EncodedBy, &'a str, *TAG_ENCODED_BY);
-impl_tag!(Composer, &'a str, *TAG_COMPOSER);
-impl_tag!(Conductor, &'a str, *TAG_CONDUCTOR);
-impl_tag!(Contact, &'a str, *TAG_CONTACT);
-impl_tag!(License, &'a str, *TAG_LICENSE);
-impl_tag!(LicenseUri, &'a str, *TAG_LICENSE_URI);
-impl_tag!(Performer, &'a str, *TAG_PERFORMER);
-impl_tag!(Duration, ::ClockTime, *TAG_DURATION);
-impl_tag!(Codec, &'a str, *TAG_CODEC);
-impl_tag!(VideoCodec, &'a str, *TAG_VIDEO_CODEC);
-impl_tag!(AudioCodec, &'a str, *TAG_AUDIO_CODEC);
-impl_tag!(SubtitleCodec, &'a str, *TAG_SUBTITLE_CODEC);
-impl_tag!(ContainerFormat, &'a str, *TAG_CONTAINER_FORMAT);
-impl_tag!(Bitrate, u32, *TAG_BITRATE);
-impl_tag!(NominalBitrate, u32, *TAG_NOMINAL_BITRATE);
-impl_tag!(MinimumBitrate, u32, *TAG_MINIMUM_BITRATE);
-impl_tag!(MaximumBitrate, u32, *TAG_MAXIMUM_BITRATE);
-impl_tag!(Serial, u32, *TAG_SERIAL);
-impl_tag!(Encoder, &'a str, *TAG_ENCODER);
-impl_tag!(EncoderVersion, u32, *TAG_ENCODER_VERSION);
-impl_tag!(TrackGain, f64, *TAG_TRACK_GAIN);
-impl_tag!(TrackPeak, f64, *TAG_TRACK_PEAK);
-impl_tag!(AlbumGain, f64, *TAG_ALBUM_GAIN);
-impl_tag!(AlbumPeak, f64, *TAG_ALBUM_PEAK);
-impl_tag!(ReferenceLevel, f64, *TAG_REFERENCE_LEVEL);
+impl_tag!(Title, &'a str, TAG_TITLE, GST_TAG_TITLE);
+impl_tag!(TitleSortname, &'a str, TAG_TITLE_SORTNAME, GST_TAG_TITLE_SORTNAME);
+impl_tag!(Artist, &'a str, TAG_ARTIST, GST_TAG_ARTIST);
+impl_tag!(ArtistSortname, &'a str, TAG_ARTIST_SORTNAME, GST_TAG_ARTIST_SORTNAME);
+impl_tag!(Album, &'a str, TAG_ALBUM, GST_TAG_ARTIST_SORTNAME);
+impl_tag!(AlbumSortname, &'a str, TAG_ALBUM_SORTNAME, GST_TAG_ALBUM_SORTNAME);
+impl_tag!(AlbumArtist, &'a str, TAG_ALBUM_ARTIST, GST_TAG_ALBUM_ARTIST);
+impl_tag!(AlbumArtistSortname, &'a str, TAG_ALBUM_ARTIST_SORTNAME, GST_TAG_ALBUM_ARTIST_SORTNAME);
+impl_tag!(Date, glib::Date, TAG_DATE, GST_TAG_DATE);
+impl_tag!(DateTime, ::auto::DateTime, TAG_DATE_TIME, GST_TAG_DATE_TIME);
+impl_tag!(Genre, &'a str, TAG_GENRE, GST_TAG_GENRE);
+impl_tag!(Comment, &'a str, TAG_COMMENT, GST_TAG_COMMENT);
+impl_tag!(ExtendedComment, &'a str, TAG_EXTENDED_COMMENT, GST_TAG_EXTENDED_COMMENT);
+impl_tag!(TrackNumber, u32, TAG_TRACK_NUMBER, GST_TAG_TRACK_NUMBER);
+impl_tag!(TrackCount, u32, TAG_TRACK_COUNT, GST_TAG_TRACK_COUNT);
+impl_tag!(AlbumVolumeNumber, u32, TAG_ALBUM_VOLUME_NUMBER, GST_TAG_ALBUM_VOLUME_NUMBER);
+impl_tag!(AlbumVolumeCount, u32, TAG_ALBUM_VOLUME_COUNT, GST_TAG_ALBUM_VOLUME_COUNT);
+impl_tag!(Location, &'a str, TAG_LOCATION, GST_TAG_LOCATION);
+impl_tag!(Homepage, &'a str, TAG_HOMEPAGE, GST_TAG_HOMEPAGE);
+impl_tag!(Description, &'a str, TAG_DESCRIPTION, GST_TAG_DESCRIPTION);
+impl_tag!(Version, &'a str, TAG_VERSION, GST_TAG_VERSION);
+impl_tag!(ISRC, &'a str, TAG_ISRC, GST_TAG_ISRC);
+impl_tag!(Organization, &'a str, TAG_ORGANIZATION, GST_TAG_ORGANIZATION);
+impl_tag!(Copyright, &'a str, TAG_COPYRIGHT, GST_TAG_COPYRIGHT);
+impl_tag!(CopyrightUri, &'a str, TAG_COPYRIGHT_URI, GST_TAG_COPYRIGHT_URI);
+impl_tag!(EncodedBy, &'a str, TAG_ENCODED_BY, GST_TAG_ENCODED_BY);
+impl_tag!(Composer, &'a str, TAG_COMPOSER, GST_TAG_COMPOSER);
+impl_tag!(Conductor, &'a str, TAG_CONDUCTOR, GST_TAG_CONDUCTOR);
+impl_tag!(Contact, &'a str, TAG_CONTACT, GST_TAG_CONTACT);
+impl_tag!(License, &'a str, TAG_LICENSE, GST_TAG_LICENSE);
+impl_tag!(LicenseUri, &'a str, TAG_LICENSE_URI, GST_TAG_LICENSE_URI);
+impl_tag!(Performer, &'a str, TAG_PERFORMER, GST_TAG_PERFORMER);
+impl_tag!(Duration, ::ClockTime, TAG_DURATION, GST_TAG_DURATION);
+impl_tag!(Codec, &'a str, TAG_CODEC, GST_TAG_CODEC);
+impl_tag!(VideoCodec, &'a str, TAG_VIDEO_CODEC, GST_TAG_VIDEO_CODEC);
+impl_tag!(AudioCodec, &'a str, TAG_AUDIO_CODEC, GST_TAG_AUDIO_CODEC);
+impl_tag!(SubtitleCodec, &'a str, TAG_SUBTITLE_CODEC, GST_TAG_SUBTITLE_CODEC);
+impl_tag!(ContainerFormat, &'a str, TAG_CONTAINER_FORMAT, GST_TAG_CONTAINER_FORMAT);
+impl_tag!(Bitrate, u32, TAG_BITRATE, GST_TAG_BITRATE);
+impl_tag!(NominalBitrate, u32, TAG_NOMINAL_BITRATE, GST_TAG_NOMINAL_BITRATE);
+impl_tag!(MinimumBitrate, u32, TAG_MINIMUM_BITRATE, GST_TAG_MINIMUM_BITRATE);
+impl_tag!(MaximumBitrate, u32, TAG_MAXIMUM_BITRATE, GST_TAG_MAXIMUM_BITRATE);
+impl_tag!(Serial, u32, TAG_SERIAL, GST_TAG_SERIAL);
+impl_tag!(Encoder, &'a str, TAG_ENCODER, GST_TAG_ENCODER);
+impl_tag!(EncoderVersion, u32, TAG_ENCODER_VERSION, GST_TAG_ENCODER_VERSION);
+impl_tag!(TrackGain, f64, TAG_TRACK_GAIN, GST_TAG_TRACK_GAIN);
+impl_tag!(TrackPeak, f64, TAG_TRACK_PEAK, GST_TAG_TRACK_PEAK);
+impl_tag!(AlbumGain, f64, TAG_ALBUM_GAIN, GST_TAG_ALBUM_GAIN);
+impl_tag!(AlbumPeak, f64, TAG_ALBUM_PEAK, GST_TAG_ALBUM_PEAK);
+impl_tag!(ReferenceLevel, f64, TAG_REFERENCE_LEVEL, GST_TAG_REFERENCE_LEVEL);
 // TODO: Should ideally enforce this to be ISO-639
-impl_tag!(LanguageCode, &'a str, *TAG_LANGUAGE_CODE);
-impl_tag!(LanguageName, &'a str, *TAG_LANGUAGE_NAME);
-impl_tag!(Image, Sample, *TAG_IMAGE);
-impl_tag!(PreviewImage, Sample, *TAG_PREVIEW_IMAGE);
-impl_tag!(Attachment, Sample, *TAG_ATTACHMENT);
-impl_tag!(BeatsPerMinute, f64, *TAG_BEATS_PER_MINUTE);
-impl_tag!(Keywords, &'a str, *TAG_KEYWORDS);
-impl_tag!(GeoLocationName, &'a str, *TAG_GEO_LOCATION_NAME);
-impl_tag!(GeoLocationLatitude, f64, *TAG_GEO_LOCATION_LATITUDE);
-impl_tag!(GeoLocationLongitute, f64, *TAG_GEO_LOCATION_LONGITUDE);
-impl_tag!(GeoLocationElevation, f64, *TAG_GEO_LOCATION_ELEVATION);
-impl_tag!(GeoLocationCity, &'a str, *TAG_GEO_LOCATION_CITY);
-impl_tag!(GeoLocationCountry, &'a str, *TAG_GEO_LOCATION_COUNTRY);
+impl_tag!(LanguageCode, &'a str, TAG_LANGUAGE_CODE, GST_TAG_LANGUAGE_CODE);
+impl_tag!(LanguageName, &'a str, TAG_LANGUAGE_NAME, GST_TAG_LANGUAGE_NAME);
+impl_tag!(Image, Sample, TAG_IMAGE, GST_TAG_IMAGE);
+impl_tag!(PreviewImage, Sample, TAG_PREVIEW_IMAGE, GST_TAG_PREVIEW_IMAGE);
+impl_tag!(Attachment, Sample, TAG_ATTACHMENT, GST_TAG_ATTACHMENT);
+impl_tag!(BeatsPerMinute, f64, TAG_BEATS_PER_MINUTE, GST_TAG_BEATS_PER_MINUTE);
+impl_tag!(Keywords, &'a str, TAG_KEYWORDS, GST_TAG_KEYWORDS);
+impl_tag!(GeoLocationName, &'a str, TAG_GEO_LOCATION_NAME, GST_TAG_GEO_LOCATION_NAME);
+impl_tag!(GeoLocationLatitude, f64, TAG_GEO_LOCATION_LATITUDE, GST_TAG_GEO_LOCATION_LATITUDE);
+impl_tag!(GeoLocationLongitute, f64, TAG_GEO_LOCATION_LONGITUDE, GST_TAG_GEO_LOCATION_LONGITUDE);
+impl_tag!(GeoLocationElevation, f64, TAG_GEO_LOCATION_ELEVATION, GST_TAG_GEO_LOCATION_ELEVATION);
+impl_tag!(GeoLocationCity, &'a str, TAG_GEO_LOCATION_CITY, GST_TAG_GEO_LOCATION_CITY);
+impl_tag!(GeoLocationCountry, &'a str, TAG_GEO_LOCATION_COUNTRY, GST_TAG_GEO_LOCATION_COUNTRY);
 impl_tag!(
     GeoLocationSublocation,
     &'a str,
-    *TAG_GEO_LOCATION_SUBLOCATION
+    TAG_GEO_LOCATION_SUBLOCATION, GST_TAG_GEO_LOCATION_SUBLOCATION
 );
 impl_tag!(
     GeoLocationHorizontalError,
     f64,
-    *TAG_GEO_LOCATION_HORIZONTAL_ERROR
+    TAG_GEO_LOCATION_HORIZONTAL_ERROR, GST_TAG_GEO_LOCATION_HORIZONTAL_ERROR
 );
 impl_tag!(
     GeoLocationMovementDirection,
     f64,
-    *TAG_GEO_LOCATION_MOVEMENT_DIRECTION
+    TAG_GEO_LOCATION_MOVEMENT_DIRECTION, GST_TAG_GEO_LOCATION_MOVEMENT_DIRECTION
 );
 impl_tag!(
     GeoLocationMovementSpeed,
     f64,
-    *TAG_GEO_LOCATION_MOVEMENT_SPEED
+    TAG_GEO_LOCATION_MOVEMENT_SPEED, GST_TAG_GEO_LOCATION_MOVEMENT_SPEED
 );
 impl_tag!(
     GeoLocationCaptureDirection,
     f64,
-    *TAG_GEO_LOCATION_CAPTURE_DIRECTION
+    TAG_GEO_LOCATION_CAPTURE_DIRECTION, GST_TAG_GEO_LOCATION_CAPTURE_DIRECTION
 );
-impl_tag!(ShowName, &'a str, *TAG_SHOW_NAME);
-impl_tag!(ShowSortname, &'a str, *TAG_SHOW_SORTNAME);
-impl_tag!(ShowEpisodeNumber, u32, *TAG_SHOW_EPISODE_NUMBER);
-impl_tag!(ShowSeasonNumber, u32, *TAG_SHOW_SEASON_NUMBER);
-impl_tag!(Lyrics, &'a str, *TAG_LYRICS);
-impl_tag!(ComposerSortname, &'a str, *TAG_COMPOSER_SORTNAME);
-impl_tag!(Grouping, &'a str, *TAG_GROUPING);
-impl_tag!(UserRating, u32, *TAG_USER_RATING);
-impl_tag!(DeviceManufacturer, &'a str, *TAG_DEVICE_MANUFACTURER);
-impl_tag!(DeviceModel, &'a str, *TAG_DEVICE_MODEL);
-impl_tag!(ApplicationName, &'a str, *TAG_APPLICATION_NAME);
-impl_tag!(ApplicationData, Sample, *TAG_APPLICATION_DATA);
-impl_tag!(ImageOrientation, &'a str, *TAG_IMAGE_ORIENTATION);
-impl_tag!(Publisher, &'a str, *TAG_PUBLISHER);
-impl_tag!(InterpretedBy, &'a str, *TAG_INTERPRETED_BY);
-impl_tag!(MidiBaseNote, &'a str, *TAG_MIDI_BASE_NOTE);
-impl_tag!(PrivateData, Sample, *TAG_PRIVATE_DATA);
-
-lazy_static! {
-    static ref TAG_TITLE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_TITLE).to_str().unwrap() };
-    static ref TAG_TITLE_SORTNAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_TITLE_SORTNAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_ARTIST: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ARTIST).to_str().unwrap() };
-    static ref TAG_ARTIST_SORTNAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_ARTIST_SORTNAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_ALBUM: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ALBUM).to_str().unwrap() };
-    static ref TAG_ALBUM_SORTNAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_ALBUM_SORTNAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_ALBUM_ARTIST: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ALBUM_ARTIST).to_str().unwrap() };
-    static ref TAG_ALBUM_ARTIST_SORTNAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_ALBUM_ARTIST_SORTNAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_DATE: &'static str = unsafe { CStr::from_ptr(ffi::GST_TAG_DATE).to_str().unwrap() };
-    static ref TAG_DATE_TIME: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_DATE_TIME).to_str().unwrap() };
-    static ref TAG_GENRE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_GENRE).to_str().unwrap() };
-    static ref TAG_COMMENT: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_COMMENT).to_str().unwrap() };
-    static ref TAG_EXTENDED_COMMENT: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_EXTENDED_COMMENT)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_TRACK_NUMBER: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_TRACK_NUMBER).to_str().unwrap() };
-    static ref TAG_TRACK_COUNT: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_TRACK_COUNT).to_str().unwrap() };
-    static ref TAG_ALBUM_VOLUME_NUMBER: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_ALBUM_VOLUME_NUMBER)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_ALBUM_VOLUME_COUNT: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_ALBUM_VOLUME_COUNT)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_LOCATION: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_LOCATION).to_str().unwrap() };
-    static ref TAG_HOMEPAGE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_HOMEPAGE).to_str().unwrap() };
-    static ref TAG_DESCRIPTION: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_DESCRIPTION).to_str().unwrap() };
-    static ref TAG_VERSION: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_VERSION).to_str().unwrap() };
-    static ref TAG_ISRC: &'static str = unsafe { CStr::from_ptr(ffi::GST_TAG_ISRC).to_str().unwrap() };
-    static ref TAG_ORGANIZATION: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ORGANIZATION).to_str().unwrap() };
-    static ref TAG_COPYRIGHT: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_COPYRIGHT).to_str().unwrap() };
-    static ref TAG_COPYRIGHT_URI: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_COPYRIGHT_URI).to_str().unwrap() };
-    static ref TAG_ENCODED_BY: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ENCODED_BY).to_str().unwrap() };
-    static ref TAG_COMPOSER: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_COMPOSER).to_str().unwrap() };
-    static ref TAG_CONDUCTOR: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_CONDUCTOR).to_str().unwrap() };
-    static ref TAG_CONTACT: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_CONTACT).to_str().unwrap() };
-    static ref TAG_LICENSE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_LICENSE).to_str().unwrap() };
-    static ref TAG_LICENSE_URI: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_LICENSE_URI).to_str().unwrap() };
-    static ref TAG_PERFORMER: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_PERFORMER).to_str().unwrap() };
-    static ref TAG_DURATION: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_DURATION).to_str().unwrap() };
-    static ref TAG_CODEC: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_CODEC).to_str().unwrap() };
-    static ref TAG_VIDEO_CODEC: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_VIDEO_CODEC).to_str().unwrap() };
-    static ref TAG_AUDIO_CODEC: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_AUDIO_CODEC).to_str().unwrap() };
-    static ref TAG_SUBTITLE_CODEC: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_SUBTITLE_CODEC)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_CONTAINER_FORMAT: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_CONTAINER_FORMAT)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_BITRATE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_BITRATE).to_str().unwrap() };
-    static ref TAG_NOMINAL_BITRATE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_NOMINAL_BITRATE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_MINIMUM_BITRATE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_MINIMUM_BITRATE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_MAXIMUM_BITRATE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_MAXIMUM_BITRATE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_SERIAL: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_SERIAL).to_str().unwrap() };
-    static ref TAG_ENCODER: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ENCODER).to_str().unwrap() };
-    static ref TAG_ENCODER_VERSION: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_ENCODER_VERSION)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_TRACK_GAIN: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_TRACK_GAIN).to_str().unwrap() };
-    static ref TAG_TRACK_PEAK: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_TRACK_PEAK).to_str().unwrap() };
-    static ref TAG_ALBUM_GAIN: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ALBUM_GAIN).to_str().unwrap() };
-    static ref TAG_ALBUM_PEAK: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ALBUM_PEAK).to_str().unwrap() };
-    static ref TAG_REFERENCE_LEVEL: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_REFERENCE_LEVEL)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_LANGUAGE_CODE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_LANGUAGE_CODE).to_str().unwrap() };
-    static ref TAG_LANGUAGE_NAME: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_LANGUAGE_NAME).to_str().unwrap() };
-    static ref TAG_IMAGE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_IMAGE).to_str().unwrap() };
-    static ref TAG_PREVIEW_IMAGE: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_PREVIEW_IMAGE).to_str().unwrap() };
-    static ref TAG_ATTACHMENT: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_ATTACHMENT).to_str().unwrap() };
-    static ref TAG_BEATS_PER_MINUTE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_BEATS_PER_MINUTE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_KEYWORDS: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_KEYWORDS).to_str().unwrap() };
-    static ref TAG_GEO_LOCATION_NAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_NAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_LATITUDE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_LATITUDE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_LONGITUDE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_LONGITUDE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_ELEVATION: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_ELEVATION)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_CITY: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_CITY)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_COUNTRY: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_COUNTRY)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_SUBLOCATION: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_SUBLOCATION)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_HORIZONTAL_ERROR: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_HORIZONTAL_ERROR)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_MOVEMENT_DIRECTION: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_MOVEMENT_DIRECTION)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_MOVEMENT_SPEED: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_MOVEMENT_SPEED)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GEO_LOCATION_CAPTURE_DIRECTION: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_GEO_LOCATION_CAPTURE_DIRECTION)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_SHOW_NAME: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_SHOW_NAME).to_str().unwrap() };
-    static ref TAG_SHOW_SORTNAME: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_SHOW_SORTNAME).to_str().unwrap() };
-    static ref TAG_SHOW_EPISODE_NUMBER: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_SHOW_EPISODE_NUMBER)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_SHOW_SEASON_NUMBER: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_SHOW_SEASON_NUMBER)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_LYRICS: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_LYRICS).to_str().unwrap() };
-    static ref TAG_COMPOSER_SORTNAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_COMPOSER_SORTNAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_GROUPING: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_GROUPING).to_str().unwrap() };
-    static ref TAG_USER_RATING: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_USER_RATING).to_str().unwrap() };
-    static ref TAG_DEVICE_MANUFACTURER: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_DEVICE_MANUFACTURER)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_DEVICE_MODEL: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_DEVICE_MODEL).to_str().unwrap() };
-    static ref TAG_APPLICATION_NAME: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_APPLICATION_NAME)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_APPLICATION_DATA: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_APPLICATION_DATA)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_IMAGE_ORIENTATION: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_IMAGE_ORIENTATION)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_PUBLISHER: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_PUBLISHER).to_str().unwrap() };
-    static ref TAG_INTERPRETED_BY: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_INTERPRETED_BY)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_MIDI_BASE_NOTE: &'static str = unsafe {
-        CStr::from_ptr(ffi::GST_TAG_MIDI_BASE_NOTE)
-            .to_str()
-            .unwrap()
-    };
-    static ref TAG_PRIVATE_DATA: &'static str =
-        unsafe { CStr::from_ptr(ffi::GST_TAG_PRIVATE_DATA).to_str().unwrap() };
-}
+impl_tag!(ShowName, &'a str, TAG_SHOW_NAME, GST_TAG_SHOW_NAME);
+impl_tag!(ShowSortname, &'a str, TAG_SHOW_SORTNAME, GST_TAG_SHOW_SORTNAME);
+impl_tag!(ShowEpisodeNumber, u32, TAG_SHOW_EPISODE_NUMBER, GST_TAG_SHOW_EPISODE_NUMBER);
+impl_tag!(ShowSeasonNumber, u32, TAG_SHOW_SEASON_NUMBER, GST_TAG_SHOW_SEASON_NUMBER);
+impl_tag!(Lyrics, &'a str, TAG_LYRICS, GST_TAG_LYRICS);
+impl_tag!(ComposerSortname, &'a str, TAG_COMPOSER_SORTNAME, GST_TAG_COMPOSER_SORTNAME);
+impl_tag!(Grouping, &'a str, TAG_GROUPING, GST_TAG_GROUPING);
+impl_tag!(UserRating, u32, TAG_USER_RATING, GST_TAG_USER_RATING);
+impl_tag!(DeviceManufacturer, &'a str, TAG_DEVICE_MANUFACTURER, GST_TAG_DEVICE_MANUFACTURER);
+impl_tag!(DeviceModel, &'a str, TAG_DEVICE_MODEL, GST_TAG_DEVICE_MODEL);
+impl_tag!(ApplicationName, &'a str, TAG_APPLICATION_NAME, GST_TAG_APPLICATION_NAME);
+impl_tag!(ApplicationData, Sample, TAG_APPLICATION_DATA, GST_TAG_APPLICATION_DATA);
+impl_tag!(ImageOrientation, &'a str, TAG_IMAGE_ORIENTATION, GST_TAG_IMAGE_ORIENTATION);
+impl_tag!(Publisher, &'a str, TAG_PUBLISHER, GST_TAG_PUBLISHER);
+impl_tag!(InterpretedBy, &'a str, TAG_INTERPRETED_BY, GST_TAG_INTERPRETED_BY);
+impl_tag!(MidiBaseNote, &'a str, TAG_MIDI_BASE_NOTE, GST_TAG_MIDI_BASE_NOTE);
+impl_tag!(PrivateData, Sample, TAG_PRIVATE_DATA, GST_TAG_PRIVATE_DATA);
 
 pub type TagList = GstRc<TagListRef>;
 pub struct TagListRef(ffi::GstTagList);


### PR DESCRIPTION
Allows iterating over all the tags without knowing the specific tags and therefore types.

Allows iterating over all the tags in the TagList with something like:
```
for i in 0..tags.n_tags() {
  let tag_name = tags.nth_tag(i as u32);
  for j in 0..tags.get_size_dynamic(tag_name); {
    let v = tags.get_index_dynamic (tag_name, j).unwrap();
    match &v.type_() {
      glib::types::Type::String => println!("{} {}", tag_name, v.get::<String>().unwrap()),
      glib::types::Type::U32 => println!("{} {}", tag_name, v.get::<u32>().unwrap()),
      glib::types::Type::I32 => println!("{} {}", tag_name, v.get::<i32>().unwrap()),
      glib::types::Type::U64 => println!("{} {}", tag_name, v.get::<u64>().unwrap()),
      glib::types::Type::I64 => println!("{} {}", tag_name, v.get::<i64>().unwrap()),
      _ => println!("Unknown value type for tag {}", tag_name),
    }
  }
}
```