### PR TITLE
GstPlayer: Expose PlayerVisualization name and description

### DIFF
--- a/gstreamer-player/src/lib.rs
+++ b/gstreamer-player/src/lib.rs
@@ -51,6 +51,7 @@ mod player_video_info;
 
 mod player_g_main_context_signal_dispatcher;
 mod player_video_overlay_video_renderer;
+mod player_visualization;
 
 // Re-export all the traits in a prelude module, so that applications
 // can always "use gst::prelude::*" without getting conflicts

--- a/gstreamer-player/src/player_visualization.rs
+++ b/gstreamer-player/src/player_visualization.rs
@@ -1,0 +1,30 @@
+// Copyright (C) 2018 Philippe Normand <philn@igalia.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use glib::translate::*;
+use std::ffi::CStr;
+
+use PlayerVisualization;
+
+impl PlayerVisualization {
+    pub fn name(&self) -> &str {
+        unsafe {
+            CStr::from_ptr((*self.to_glib_none().0).name)
+                .to_str()
+                .unwrap()
+        }
+    }
+
+    pub fn description(&self) -> &str {
+        unsafe {
+            CStr::from_ptr((*self.to_glib_none().0).description)
+                .to_str()
+                .unwrap()
+        }
+    }
+}


### PR DESCRIPTION
The name is the identifier of the visualization that has to be passed to
gstreamer_player::Player::set_visualization().

Fixes #111