### PR TITLE
gstreamer: Implement deinit() function

### DIFF
--- a/gstreamer/src/lib.rs
+++ b/gstreamer/src/lib.rs
@@ -255,6 +255,10 @@ pub fn init() -> Result<(), glib::Error> {
     }
 }
 
+pub unsafe fn deinit() {
+    ffi::gst_deinit();
+}
+
 pub const BUFFER_OFFSET_NONE: u64 = ffi::GST_BUFFER_OFFSET_NONE;
 pub const CLOCK_TIME_NONE: ClockTime = ClockTime(None);
 


### PR DESCRIPTION
This function is especially usefull when using the leaks tracer. It was removed
in commit e7a0543c.