### PR TITLE
Gitlab CI config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,51 @@
+stages:
+  - "test"
+
+.cargo_test_template: &cargo_test
+  stage: "test"
+  variables:
+    DEPENDENCIES: |
+      curl
+      liborc-dev
+      libglib2.0-dev
+      libxml2-dev
+      libgtk-3-dev
+      libegl1-mesa
+      libgles2-mesa
+      libgl1-mesa-dri
+      libgl1-mesa-glx
+      libwayland-egl1-mesa
+
+  before_script:
+    - apt-get update -yqq
+    - apt-get install -yqq --no-install-recommends $DEPENDENCIES
+    - mkdir -p precompiled-gst && cd precompiled-gst
+
+    - curl -L https://people.freedesktop.org/~slomo/gstreamer-1.14.3.tar.gz | tar xz
+    - sed -i "s;prefix=/root/gstreamer;prefix=$PWD/gstreamer;g" $PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc
+    - export PKG_CONFIG_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig
+    - export GST_PLUGIN_SYSTEM_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu/gstreamer-1.0
+    - export GST_PLUGIN_SCANNER=$PWD/gstreamer/libexec/gstreamer-1.0/gst-plugin-scanner
+    - export PATH=$PATH:$PWD/gstreamer/bin
+    - export LD_LIBRARY_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+  script:
+    - rustc --version
+    - cargo build --all
+    - G_DEBUG=fatal_warnings cargo test --all
+    - cargo build --all --all-features
+    - G_DEBUG=fatal_warnings cargo test --all --all-features
+
+
+test stable:
+  # Stable img
+  # https://hub.docker.com/_/rust/
+  image: "rust:slim"
+  <<: *cargo_test
+
+test nightly:
+  # Nightly
+  # https://hub.docker.com/r/rustlang/rust/
+  image: "rustlang/rust:nightly-slim"
+  allow_failure: true
+  <<: *cargo_test
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,10 +30,10 @@ stages:
     - export LD_LIBRARY_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
   script:
     - rustc --version
-    - cargo build --all
-    - G_DEBUG=fatal_warnings cargo test --all
-    - cargo build --all --all-features
-    - G_DEBUG=fatal_warnings cargo test --all --all-features
+    - cargo build --color=always --all
+    - G_DEBUG=fatal_warnings cargo test --color=always --all
+    - cargo build --color=always --all --all-features
+    - G_DEBUG=fatal_warnings cargo test --color=always --all --all-features
 
 
 test stable:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - "test"
+  - "lint"
 
 .cargo_cache: &cache
   cache:
@@ -60,3 +61,11 @@ test nightly:
   image: "rustlang/rust:nightly-slim"
   allow_failure: true
   <<: *cargo_test
+
+rustfmt:
+  image: "rustlang/rust:nightly-slim"
+  stage: "lint"
+  script:
+    - rustup component add rustfmt-preview
+    - cargo fmt --version
+    - cargo fmt -- --color=always --check

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,12 @@
 stages:
   - "test"
 
+.cargo_cache: &cache
+  cache:
+    key: "gst"
+    paths:
+      - ".cargo_cache/"
+
 .cargo_test_template: &cargo_test
   stage: "test"
   variables:
@@ -16,9 +22,15 @@ stages:
       libgl1-mesa-glx
       libwayland-egl1-mesa
 
+  <<: *cache
   before_script:
     - apt-get update -yqq
     - apt-get install -yqq --no-install-recommends $DEPENDENCIES
+
+    # Only stuff inside the repo directory can be cached
+    # Override the CARGO_HOME variable to force its location
+    - export CARGO_HOME="${PWD}/.cargo_cache"
+
     - mkdir -p precompiled-gst && cd precompiled-gst
 
     - curl -L https://people.freedesktop.org/~slomo/gstreamer-1.14.3.tar.gz | tar xz
@@ -48,4 +60,3 @@ test nightly:
   image: "rustlang/rust:nightly-slim"
   allow_failure: true
   <<: *cargo_test
-

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,14 @@
+ignore = [
+    "gstreamer/src/auto/",
+    "gstreamer-app/src/auto",
+    "gstreamer-audio/src/auto",
+    "gstreamer-base/src/auto",
+    "gstreamer-net/src/auto",
+    "gstreamer-pbutils/src/auto",
+    "gstreamer-player/src/auto",
+    "gstreamer-rtsp/src/auto",
+    "gstreamer-rtsp-server/src/auto",
+    "gstreamer-sdp/src/auto",
+    "gstreamer-video/src/auto",
+    "gstreamer-webrtc/src/auto",
+]


### PR DESCRIPTION
Preparing for the gitlab migration

One thing to note is that travis was using a `ubuntu trusty` base, where now we are using the rust docker images, both based on debian stable. Sadly the tarball hack is still with us, though I plan on getting rid of it in the future.

There is also a `rustfmt` job, currently the pipeline becomes red if it fails, but it can also be set to `allow_failure: true`.

Pipeline results: https://gitlab.freedesktop.org/alatiera/gstreamer-rs/pipelines/5458