### PR TITLE
fix initialization of ptp clock

### DIFF
--- a/gstreamer-net/src/ptp_clock.rs
+++ b/gstreamer-net/src/ptp_clock.rs
@@ -16,9 +16,7 @@ use gst;
 impl PtpClock {
     pub fn new<'a, P: Into<Option<&'a str>>>(
         name: P,
-        remote_address: &str,
-        remote_port: i32,
-        base_time: gst::ClockTime,
+        domain: u32,
     ) -> PtpClock {
         assert_initialized_main_thread!();
         let name = name.into();
@@ -26,24 +24,14 @@ impl PtpClock {
         let (major, minor, _, _) = gst::version();
         if (major, minor) > (1, 12) {
             unsafe {
-                gst::Clock::from_glib_full(ffi::gst_ntp_clock_new(
-                    name.0,
-                    remote_address.to_glib_none().0,
-                    remote_port,
-                    base_time.to_glib(),
-                ))
-                .downcast_unchecked()
+                gst::Clock::from_glib_full(ffi::gst_ptp_clock_new(name.0, domain))
+                    .downcast_unchecked()
             }
         } else {
             // Workaround for bad floating reference handling in 1.12. This issue was fixed for 1.13
             unsafe {
-                gst::Clock::from_glib_none(ffi::gst_ntp_clock_new(
-                    name.0,
-                    remote_address.to_glib_none().0,
-                    remote_port,
-                    base_time.to_glib(),
-                ))
-                .downcast_unchecked()
+                gst::Clock::from_glib_none(ffi::gst_ptp_clock_new(name.0, domain))
+                    .downcast_unchecked()
             }
         }
     }


### PR DESCRIPTION
The ptp clock was initialized as an ntp clock.