### PR TITLE
No longer needs `--with-*` option for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,10 @@ provided by the GStreamer project.
 
 #### Homebrew
 
-Homebrew only installs various plugins if explicitly enabled, so some extra
-`--with-*` flags may be required.
-
 ```
 $ brew install gstreamer gst-plugins-base gst-plugins-good \
       gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server \
-      gst-editing-services --with-orc --with-libogg --with-opus \
-      --with-pango --with-theora --with-libvorbis --with-libvpx \
-      --enable-gtk3
+      gst-editing-services
 ```
 
 If you wish to install the gstreamer-player sub-crate, make sure the


### PR DESCRIPTION
According to official change log in homebrew 2.0(https://brew.sh/2019/02/02/homebrew-2.0.0/), the `--with-*` option was removed.
I think this can be installed without these `--with` options.

>Homebrew does not have any formulae with options in Homebrew/homebrew-core. Options will still be supported and encouraged by third-party taps. This change allows us to better focus on delivering binary packages rather than options. Formulae with options had to be built from source, could not be tested on our CI system and provided a disproportionate support burden on our volunteer maintainers.