### PR TITLE
examples: remove the use of description() in Error

### DIFF
--- a/examples/src/bin/decodebin.rs
+++ b/examples/src/bin/decodebin.rs
@@ -286,7 +286,7 @@ fn example_main() -> Result<(), Error> {
                             .get_src()
                             .map(|s| String::from(s.get_path_string()))
                             .unwrap_or_else(|| String::from("None")),
-                        error: err.get_error().description().into(),
+                        error: err.get_error().to_string(),
                         debug: err.get_debug(),
                         cause: err.get_error(),
                     }

--- a/examples/src/bin/encodebin.rs
+++ b/examples/src/bin/encodebin.rs
@@ -316,7 +316,7 @@ fn example_main() -> Result<(), Error> {
                             .get_src()
                             .map(|s| String::from(s.get_path_string()))
                             .unwrap_or_else(|| String::from("None")),
-                        error: err.get_error().description().into(),
+                        error: err.get_error().to_string(),
                         debug: err.get_debug(),
                         cause: err.get_error(),
                     }


### PR DESCRIPTION
Replace the use of deprecated method "Error::description()"
with to_string() method