### PR TITLE
Fix Buffer Serialize struct length

### DIFF
--- a/gstreamer/src/buffer_serde.rs
+++ b/gstreamer/src/buffer_serde.rs
@@ -14,7 +14,7 @@ use crate::{Buffer, BufferFlags, BufferRef, ClockTime};
 
 impl Serialize for BufferRef {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut buffer = serializer.serialize_struct("Buffer", 6)?;
+        let mut buffer = serializer.serialize_struct("Buffer", 7)?;
         buffer.serialize_field("pts", &self.pts())?;
         buffer.serialize_field("dts", &self.dts())?;
         buffer.serialize_field("duration", &self.duration())?;


### PR DESCRIPTION
I noticed that `rmp-serde` and `serde_cbor`/`ciborium` both fail to deserialize the gstreamer::Buffer object because the encoded struct size is incorrect. There are 7 elements in the struct, but the serializer only specifies 6.

It is curious that `serde_json` worked correctly, but binary serialization did not.